### PR TITLE
Add PAM package

### DIFF
--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -46,7 +46,6 @@ var (
 	ErrCanceled           = errors.New("operation canceled")
 	ErrNoDesctructiveOps  = errors.New("operation would be destructive")
 	ErrMaxPassphrase      = util.SystemError("max passphrase length exceeded")
-	ErrPAMPassphrase      = errors.New("incorrect login passphrase")
 	ErrInvalidSource      = errors.New("invalid source type")
 	ErrPassphraseMismatch = errors.New("entered passphrases do not match")
 	ErrSpecifyProtector   = errors.New("multiple protectors available")
@@ -59,6 +58,7 @@ var (
 	ErrBadOwners          = errors.New("you do not own this directory")
 	ErrNotEmptyDir        = errors.New("not an empty directory")
 	ErrNotPassphrase      = errors.New("protector does not use a passphrase")
+	ErrUnknownUser        = errors.New("unknown user")
 )
 
 var loadHelpText = fmt.Sprintf("You may need to mount a linked filesystem. Run with %s for more information.", shortDisplay(verboseFlag))

--- a/pam/constants.go
+++ b/pam/constants.go
@@ -1,0 +1,110 @@
+/*
+ * constants.go - PAM flags and item types from github.com/msteinert/pam
+ *
+ * Modifications Copyright 2017 Google Inc.
+ * Modifications Author: Joe Richey (joerichey@google.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/*
+ * Copyright 2011, krockot
+ * Copyright 2015, Michael Steinert <mike.steinert@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package pam
+
+/*
+#cgo LDFLAGS: -lpam
+
+#include <security/pam_modules.h>
+*/
+import "C"
+
+// Item is a an PAM information type.
+type Item int
+
+// PAM Item types.
+const (
+	// Service is the name which identifies the PAM stack.
+	Service Item = C.PAM_SERVICE
+	// User identifies the username identity used by a service.
+	User = C.PAM_USER
+	// Tty is the terminal name.
+	Tty = C.PAM_TTY
+	// Rhost is the requesting host name.
+	Rhost = C.PAM_RHOST
+	// Authtok is the currently active authentication token.
+	Authtok = C.PAM_AUTHTOK
+	// Oldauthtok is the old authentication token.
+	Oldauthtok = C.PAM_OLDAUTHTOK
+	// Ruser is the requesting user name.
+	Ruser = C.PAM_RUSER
+	// UserPrompt is the string use to prompt for a username.
+	UserPrompt = C.PAM_USER_PROMPT
+)
+
+// Flag is used as input to various PAM functions. Flags can be combined with a
+// bitwise or. Refer to the official PAM documentation for which flags are
+// accepted by which functions.
+type Flag int
+
+// PAM Flag types.
+const (
+	// Silent indicates that no messages should be emitted.
+	Silent Flag = C.PAM_SILENT
+	// DisallowNullAuthtok indicates that authorization should fail
+	// if the user does not have a registered authentication token.
+	DisallowNullAuthtok = C.PAM_DISALLOW_NULL_AUTHTOK
+	// EstablishCred indicates that credentials should be established
+	// for the user.
+	EstablishCred = C.PAM_ESTABLISH_CRED
+	// DeleteCred inidicates that credentials should be deleted.
+	DeleteCred = C.PAM_DELETE_CRED
+	// ReinitializeCred indicates that credentials should be fully
+	// reinitialized.
+	ReinitializeCred = C.PAM_REINITIALIZE_CRED
+	// RefreshCred indicates that the lifetime of existing credentials
+	// should be extended.
+	RefreshCred = C.PAM_REFRESH_CRED
+	// ChangeExpiredAuthtok indicates that the authentication token
+	// should be changed if it has expired.
+	ChangeExpiredAuthtok = C.PAM_CHANGE_EXPIRED_AUTHTOK
+	// PrelimCheck indicates that the modules are being probed as to their
+	// ready status for altering the user's authentication token.
+	PrelimCheck = C.PAM_PRELIM_CHECK
+	// UpdateAuthtok informs the module that this is the call it should
+	// change the authorization tokens.
+	UpdateAuthtok = C.PAM_UPDATE_AUTHTOK
+)

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -1,0 +1,190 @@
+/*
+ * pam.go - Utility functions for interfacing with the PAM libraries.
+ *
+ * Copyright 2017 Google Inc.
+ * Author: Joe Richey (joerichey@google.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package pam
+
+/*
+#cgo LDFLAGS: -lpam
+#include "pam.h"
+
+#include <pwd.h>
+#include <stdlib.h>
+#include <security/pam_modules.h>
+*/
+import "C"
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"github.com/google/fscrypt/util"
+)
+
+// Handle wraps the C pam_handle_t type. This is used from within modules.
+type Handle struct {
+	handle *C.pam_handle_t
+	status C.int
+}
+
+// NewHandle creates a Handle from a raw pointer.
+func NewHandle(pamh unsafe.Pointer) *Handle {
+	return &Handle{
+		handle: (*C.pam_handle_t)(pamh),
+		status: C.PAM_SUCCESS,
+	}
+}
+
+func (h *Handle) setData(name string, data unsafe.Pointer, cleanup C.CleanupFunc) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	h.status = C.pam_set_data(h.handle, cName, data, cleanup)
+	return h.err()
+}
+
+func (h *Handle) getData(name string) (unsafe.Pointer, error) {
+	var data unsafe.Pointer
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	h.status = C.pam_get_data(h.handle, cName, &data)
+	return data, h.err()
+}
+
+func (h *Handle) SetSecret(name string, secret unsafe.Pointer) error {
+	return h.setData(name, C.copyIntoSecret(secret), C.CleanupFunc(C.freeSecret))
+}
+
+func (h *Handle) GetSecret(name string) (unsafe.Pointer, error) {
+	return h.getData(name)
+}
+
+func (h *Handle) ClearSecret(name string) error {
+	return h.setData(name, unsafe.Pointer(C.CString("")), C.CleanupFunc(C.freeData))
+}
+
+func (h *Handle) SetString(name string, s string) error {
+	return h.setData(name, unsafe.Pointer(C.CString(s)), C.CleanupFunc(C.freeData))
+}
+
+func (h *Handle) GetString(name string) (string, error) {
+	data, err := h.getData(name)
+	if err != nil {
+		return "", err
+	}
+	return C.GoString((*C.char)(data)), nil
+}
+
+func (h *Handle) SetSlice(name string, slice []string) error {
+	sliceLength := uintptr(len(slice))
+	memorySize := (sliceLength + 1) * unsafe.Sizeof(uintptr(0))
+	data := C.malloc(C.size_t(memorySize))
+
+	cSlice := util.PointerSlice(data)
+	for i, str := range slice {
+		cSlice[i] = unsafe.Pointer(C.CString(str))
+	}
+	cSlice[sliceLength] = nil
+
+	return h.setData(name, data, C.CleanupFunc(C.freeArray))
+}
+
+func (h *Handle) GetSlice(name string) ([]string, error) {
+	data, err := h.getData(name)
+	if err != nil {
+		return nil, err
+	}
+
+	var slice []string
+	for _, cString := range util.PointerSlice(data) {
+		if cString == nil {
+			return slice, nil
+		}
+		slice = append(slice, C.GoString((*C.char)(cString)))
+	}
+	panic("We will never get here")
+}
+
+// GetItem retrieves a PAM information item. This a pointer directory to the
+// data, so it shouldn't be modified.
+func (h *Handle) GetItem(i Item) (unsafe.Pointer, error) {
+	var data unsafe.Pointer
+	h.status = C.pam_get_item(h.handle, C.int(i), &data)
+	return data, h.err()
+}
+
+// GetUID retrieves the UID of the corresponding PAM_USER.
+func (h *Handle) GetUID() (int64, error) {
+	var pamUsername *C.char
+	h.status = C.pam_get_user(h.handle, &pamUsername, nil)
+	if err := h.err(); err != nil {
+		return 0, err
+	}
+
+	pwd := C.getpwnam(pamUsername)
+	if pwd == nil {
+		return 0, fmt.Errorf("unknown user %q", C.GoString(pamUsername))
+	}
+	return int64(pwd.pw_uid), nil
+}
+
+func (h *Handle) err() error {
+	if h.status == C.PAM_SUCCESS {
+		return nil
+	}
+	s := C.GoString(C.pam_strerror(h.handle, C.int(h.status)))
+	return errors.New(s)
+}
+
+// Transaction represents a wrapped pam_handle_t type created with pam_start
+// form an application.
+type Transaction Handle
+
+// Start initializes a pam Transaction. End() should be called after the
+// Transaction is no longer needed.
+func Start(service, username string) (*Transaction, error) {
+	cService := C.CString(service)
+	defer C.free(unsafe.Pointer(cService))
+	cUsername := C.CString(username)
+	defer C.free(unsafe.Pointer(cUsername))
+
+	t := &Transaction{
+		handle: nil,
+		status: C.PAM_SUCCESS,
+	}
+	t.status = C.pam_start(cService, cUsername, &C.conv, &t.handle)
+	return t, (*Handle)(t).err()
+}
+
+// End finalizes a pam Transaction with pam_end().
+func (t *Transaction) End() {
+	C.pam_end(t.handle, t.status)
+}
+
+// Authenticate returns a boolean indicating if the user authenticated correctly
+// or not. If the authentication check did not complete, an error is returned.
+func (t *Transaction) Authenticate(quiet bool) (bool, error) {
+	var flags C.int = C.PAM_DISALLOW_NULL_AUTHTOK
+	if quiet {
+		flags |= C.PAM_SILENT
+	}
+	t.status = C.pam_authenticate(t.handle, flags)
+	if t.status == C.PAM_AUTH_ERR {
+		return false, nil
+	}
+	return true, (*Handle)(t).err()
+}

--- a/pam/pam.h
+++ b/pam/pam.h
@@ -22,10 +22,23 @@
 
 #include <security/pam_appl.h>
 
-// fscrypt_service is the display name of the service requesting the passphrase.
-const char* fscrypt_service;
+// Conversation that will call back into Go code when appropriate.
+const struct pam_conv conv;
 
-// pam_init initializes the pam_conv structure for use with our Go callbacks.
-void pam_init(struct pam_conv* conv);
+// CleaupFuncs are used to cleanup specific PAM data.
+typedef void (*CleanupFunc)(pam_handle_t *pamh, void *data, int error_status);
 
-#endif
+// CleaupFunc that calls free() on data.
+void freeData(pam_handle_t *pamh, void *data, int error_status);
+
+// CleaupFunc that frees each item in a null terminated array of pointers and
+// then frees the array itself.
+void freeArray(pam_handle_t *pamh, void **array, int error_status);
+
+// Creates a copy of a C string, which resides in an locked buffer.
+void *copyIntoSecret(void *data);
+
+// CleaupFunc that Zeros wipes a C string and unlocks and frees its memory.
+void freeSecret(pam_handle_t *pamh, char *data, int error_status);
+
+#endif  // FSCRYPT_PAM_H

--- a/util/util.go
+++ b/util/util.go
@@ -37,6 +37,18 @@ func Ptr(slice []byte) unsafe.Pointer {
 	return unsafe.Pointer(&slice[0])
 }
 
+// ByteSlice takes a pointer to some data and views it as a slice of bytes.
+// Note, indexing into this slice is unsafe.
+func ByteSlice(ptr unsafe.Pointer) []byte {
+	return (*[1 << 30]byte)(ptr)[:]
+}
+
+// PointerSlice takes a pointer to an array of pointers and views it as a slice
+// of pointers. Note, indexing into this slice is unsafe.
+func PointerSlice(ptr unsafe.Pointer) []unsafe.Pointer {
+	return (*[1 << 30]unsafe.Pointer)(ptr)[:]
+}
+
 // Index returns the first index i such that inVal == inArray[i].
 // ok is true if we find a match, false otherwise.
 func Index(inVal int64, inArray []int64) (index int, ok bool) {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -20,19 +20,52 @@
 package util
 
 import (
+	"bytes"
 	"testing"
+	"unsafe"
 )
 
 const offset = 3
 
+var (
+	byteArr = []byte{'a', 'b', 'c', 'd'}
+	ptrArr  = []*int{&a, &b, &c, &d}
+	a       = 1
+	b       = 2
+	c       = 3
+	d       = 4
+)
+
 // Make sure the address behaves well under slicing
 func TestPtrOffset(t *testing.T) {
-	arr := []byte{'a', 'b', 'c', 'd'}
-	i1 := uintptr(Ptr(arr[offset:]))
-	i2 := uintptr(Ptr(arr))
+	i1 := uintptr(Ptr(byteArr[offset:]))
+	i2 := uintptr(Ptr(byteArr))
 
 	if i1 != i2+offset {
-		t.Fatalf("pointers %v and %v do not have an offset of %v", i1, i2, offset)
+		t.Errorf("pointers %v and %v do not have an offset of %v", i1, i2, offset)
+	}
+}
+
+// Tests that the ByteSlice method essentially reverses the Ptr method
+func TestByteSlice(t *testing.T) {
+	ptr := Ptr(byteArr)
+	generatedArr := ByteSlice(ptr)[:len(byteArr)]
+
+	if !bytes.Equal(byteArr, generatedArr) {
+		t.Errorf("generated array (%v) and original array (%v) do not agree",
+			generatedArr, byteArr)
+	}
+}
+
+// Tests that the PointerSlice method correctly handles Go Pointers
+func TestPointerSlice(t *testing.T) {
+	arrPtr := unsafe.Pointer(&ptrArr[0])
+
+	// Convert an array of unsafe pointers to int pointers.
+	for i, ptr := range PointerSlice(arrPtr)[:len(ptrArr)] {
+		if ptrArr[i] != (*int)(ptr) {
+			t.Errorf("generated array and original array disagree at %d", i)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR significantly updates the PAM package so we will be able to build our PAM module (see #4).
Specifically, this includes:

- Changing the `Key` struct to support creation from/to C strings
- Changing the `util` package to support more array conversions
- Changing the `pam` package to have significantly more features (using [this package](https://github.com/msteinert/pam))
- Changing `cmd/fscrypt` to support the new API
- Refactoring how unknown UIDs are handled.