### PR TITLE
Fixed cloning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ fscrypt has the following build dependencies:
 
 Once all the dependencies are installed, you can get the repository by running:
 ```shell
-go get -d github.com/google/fscrypt
+go get -d github.com/google/fscrypt/...
 ```
 and then you can run `make` in `$GOPATH/github.com/google/fscrypt` to build the
 executable in that directory. Running `sudo make install` installs the binary to


### PR DESCRIPTION
Closes #28 

The current `go get -d` instructions will show a warning because the top level directory contains no Go code. Using `go set -d github.com/google/fscrypt/...` solves this problem while still checking out the `README.md`, `Makefile`, and other documents in the root directory.