### PR TITLE
actions: calculate password hash difficulty correctly

### DIFF
--- a/actions/config.go
+++ b/actions/config.go
@@ -230,7 +230,7 @@ func timeHashingCosts(costs *metadata.HashingCosts) (time.Duration, error) {
 	}
 	end := cpuTimeInNanoseconds()
 
-	return time.Duration(end - begin), nil
+	return time.Duration((end - begin) / costs.Parallelism), nil
 }
 
 // cpuTimeInNanoseconds returns the nanosecond count based on the process's CPU usage.


### PR DESCRIPTION
'fscrypt setup' is supposed to calibrate the Argon2 password hashing
difficulty to 1s by default, but actually it was setting it to only 1s /
num_cpus because the hashing is done with all CPUs and it is timed using
the CLOCK_PROCESS_CPUTIME_ID clock, which measures the time spent by all
threads in the process.  Fix this by dividing the elapsed time by
HashingCosts.Parallelism, which is used as the number of threads.