### PR TITLE
util: Slice/Pointer conversion fits in MatInt32

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -25,6 +25,7 @@ package util
 
 import (
 	"bufio"
+	"math"
 	"os"
 	"unsafe"
 )
@@ -40,13 +41,15 @@ func Ptr(slice []byte) unsafe.Pointer {
 // ByteSlice takes a pointer to some data and views it as a slice of bytes.
 // Note, indexing into this slice is unsafe.
 func ByteSlice(ptr unsafe.Pointer) []byte {
-	return (*[1 << 30]byte)(ptr)[:]
+	// Silce must fix in 32-bit address space to build on 32-bit platforms.
+	return (*[math.MaxInt32]byte)(ptr)[:]
 }
 
 // PointerSlice takes a pointer to an array of pointers and views it as a slice
 // of pointers. Note, indexing into this slice is unsafe.
 func PointerSlice(ptr unsafe.Pointer) []unsafe.Pointer {
-	return (*[1 << 30]unsafe.Pointer)(ptr)[:]
+	// Silce must fix in 32-bit address space to build on 32-bit platforms.
+	return (*[math.MaxInt32 / 4]unsafe.Pointer)(ptr)[:]
 }
 
 // Index returns the first index i such that inVal == inArray[i].


### PR DESCRIPTION
Fixes #31 

For the pointer to slice conversion functions to work on a 32-bit architecture, the slices must not have a size that exceeds `MatInt32`. This PR increases the allowable size for the byte slices, while making sure that the pointer slices will build on 32-bit.

Unfortunately, Travis CI does not support non x86_64 builds (see: https://github.com/travis-ci/travis-ci/issues/986), so testing this will have to be done manually. 