### PR TITLE
crypto: Switch from session to user keyring

### DIFF
--- a/actions/policy.go
+++ b/actions/policy.go
@@ -365,7 +365,7 @@ func (policy *Policy) Apply(path string) error {
 // IsProvisioned returns a boolean indicating if the policy has its key in the
 // keyring, meaning files and directories using this policy are accessible.
 func (policy *Policy) IsProvisioned() bool {
-	_, _, err := crypto.FindPolicyKey(policy.Description())
+	_, err := crypto.FindPolicyKey(policy.Description())
 	return err == nil
 }
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -63,10 +63,9 @@ var (
 	ErrGetrandomFail  = util.SystemError("getrandom() failed")
 	ErrKeyAlloc       = util.SystemError("could not allocate memory for key")
 	ErrKeyFree        = util.SystemError("could not free memory of key")
-	ErrKeyringLocate  = util.SystemError("could not locate the session keyring")
-	ErrKeyringInsert  = util.SystemError("could not insert key into the session keyring")
+	ErrKeyringInsert  = util.SystemError("could not insert key into the keyring")
 	ErrKeyringSearch  = errors.New("could not find key with descriptor")
-	ErrKeyringDelete  = util.SystemError("could not delete key from the session keyring")
+	ErrKeyringDelete  = util.SystemError("could not delete key from the keyring")
 )
 
 // panicInputLength panics if "name" has invalid length (expected != actual)


### PR DESCRIPTION
Fixes #34 

This commit moves from the session keyring to the user keyring. This change also allows us to eliminate `getKeyring()` as the user keyring does not have the problems of the session keyring. There is also a small API change as we no longer need to pass along the session keyring id.