### PR TITLE
Purge command now clears cache

### DIFF
--- a/actions/context.go
+++ b/actions/context.go
@@ -31,9 +31,10 @@ package actions
 import (
 	"log"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/pkg/errors"
 
-	"github.com/google/fscrypt/crypto"
 	"github.com/google/fscrypt/filesystem"
 	"github.com/google/fscrypt/metadata"
 )
@@ -101,8 +102,10 @@ func (ctx *Context) checkContext() error {
 }
 
 // getService returns the keyring service for this context. We use the presence
-// of the LegacyConfig flag to determine if we should use the legacy services
-// (which are necessary for kernels before v4.8).
+// of the LegacyConfig flag to determine if we should use the legacy services.
+// For ext4 systems before v4.8 and f2fs systems before v4.6, filesystem
+// specific services must be used (these legacy services will still work with
+// later kernels).
 func (ctx *Context) getService() string {
 	// For legacy configurations, we may need non-standard services
 	if ctx.Config.HasCompatibilityOption(LegacyConfig) {
@@ -111,7 +114,7 @@ func (ctx *Context) getService() string {
 			return ctx.Mount.Filesystem + ":"
 		}
 	}
-	return crypto.DefaultService
+	return unix.FS_KEY_DESC_PREFIX
 }
 
 // getProtectorOption returns the ProtectorOption for the protector on the

--- a/actions/policy.go
+++ b/actions/policy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/fscrypt/crypto"
 	"github.com/google/fscrypt/filesystem"
 	"github.com/google/fscrypt/metadata"
+	"github.com/google/fscrypt/security"
 	"github.com/google/fscrypt/util"
 )
 
@@ -56,10 +57,10 @@ func PurgeAllPolicies(ctx *Context) error {
 
 	for _, policyDescriptor := range policies {
 		service := ctx.getService()
-		err = crypto.RemovePolicyKey(service + policyDescriptor)
+		err = security.RemoveKey(service + policyDescriptor)
 
 		switch errors.Cause(err) {
-		case nil, crypto.ErrKeyringSearch:
+		case nil, security.ErrKeyringSearch:
 			// We don't care if the key has already been removed
 		default:
 			return err
@@ -365,7 +366,7 @@ func (policy *Policy) Apply(path string) error {
 // IsProvisioned returns a boolean indicating if the policy has its key in the
 // keyring, meaning files and directories using this policy are accessible.
 func (policy *Policy) IsProvisioned() bool {
-	_, err := crypto.FindPolicyKey(policy.Description())
+	_, err := security.FindKey(policy.Description())
 	return err == nil
 }
 
@@ -381,7 +382,7 @@ func (policy *Policy) Provision() error {
 // Deprovision removes the Policy key from the kernel keyring. This prevents
 // reading and writing to the directory once the caches are cleared.
 func (policy *Policy) Deprovision() error {
-	return crypto.RemovePolicyKey(policy.Description())
+	return security.RemoveKey(policy.Description())
 }
 
 // commitData writes the Policy's current data to the filesystem.

--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -58,6 +58,7 @@ var (
 	ErrNotEmptyDir        = errors.New("not an empty directory")
 	ErrNotPassphrase      = errors.New("protector does not use a passphrase")
 	ErrUnknownUser        = errors.New("unknown user")
+	ErrDropCachesPerm     = errors.New("inode cache can only be dropped as root")
 )
 
 var loadHelpText = fmt.Sprintf("You may need to mount a linked filesystem. Run with %s for more information.", shortDisplay(verboseFlag))
@@ -112,6 +113,11 @@ func getErrorSuggestions(err error) string {
 			cannot be encrypted in-place. Instead, encrypt an empty
 			directory, copy the files into that encrypted directory,
 			and securely delete the originals with "shred".`
+	case ErrDropCachesPerm:
+		return fmt.Sprintf(`Either this command should be run as root to
+			properly clear the inode cache, or it should be run with
+			%s=false (this may leave encrypted files and directories
+			in an accessible state).`, shortDisplay(dropCachesFlag))
 	case ErrAllLoadsFailed:
 		return loadHelpText
 	default:

--- a/cmd/fscrypt/flags.go
+++ b/cmd/fscrypt/flags.go
@@ -158,6 +158,14 @@ var (
 			"fscrypt unlock" will need to be run in order to use the
 			directory.`,
 	}
+	dropCachesFlag = &boolFlag{
+		Name: "drop-caches",
+		Usage: `After purging the keys from the keyring, drop the
+			inode and dentry cache for the purge to take effect.
+			Without this flag, cached encrypted files may still have
+			their plaintext visible. Requires root privileges.`,
+		Default: true,
+	}
 )
 
 // Option flags: used to specify options instead of being prompted for them

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -20,7 +20,6 @@
 // Package crypto manages all the cryptography for fscrypt. This includes:
 //	- Key management (key.go)
 //		- Securely holding keys in memory
-//		- Inserting keys into the keyring
 //		- Making recovery keys
 //	- Randomness (rand.go)
 //	- Cryptographic algorithms (crypto.go)
@@ -63,9 +62,6 @@ var (
 	ErrGetrandomFail  = util.SystemError("getrandom() failed")
 	ErrKeyAlloc       = util.SystemError("could not allocate memory for key")
 	ErrKeyFree        = util.SystemError("could not free memory of key")
-	ErrKeyringInsert  = util.SystemError("could not insert key into the keyring")
-	ErrKeyringSearch  = errors.New("could not find key with descriptor")
-	ErrKeyringDelete  = util.SystemError("could not delete key from the keyring")
 )
 
 // panicInputLength panics if "name" has invalid length (expected != actual)

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -140,19 +140,19 @@ func (h *Handle) GetItem(i Item) (unsafe.Pointer, error) {
 	return data, h.err()
 }
 
-// GetUID retrieves the UID of the corresponding PAM_USER.
-func (h *Handle) GetUID() (int64, error) {
+// GetIDs retrieves the UID and GID of the corresponding PAM_USER.
+func (h *Handle) GetIDs() (uid int, gid int, err error) {
 	var pamUsername *C.char
 	h.status = C.pam_get_user(h.handle, &pamUsername, nil)
-	if err := h.err(); err != nil {
-		return 0, err
+	if err = h.err(); err != nil {
+		return 0, 0, err
 	}
 
-	pwd := C.getpwnam(pamUsername)
-	if pwd == nil {
-		return 0, fmt.Errorf("unknown user %q", C.GoString(pamUsername))
+	pwnam := C.getpwnam(pamUsername)
+	if pwnam == nil {
+		return 0, 0, fmt.Errorf("unknown user %q", C.GoString(pamUsername))
 	}
-	return int64(pwd.pw_uid), nil
+	return int(pwnam.pw_uid), int(pwnam.pw_gid), nil
 }
 
 func (h *Handle) err() error {

--- a/security/keyring.go
+++ b/security/keyring.go
@@ -95,7 +95,7 @@ var keyringIDCache = make(map[int]int)
 // simpler approach would be to use
 //     unix.KeyctlGetKeyringID(unix.KEY_SPEC_USER_KEYRING, false)
 // which would work in almost all cases. However, despite the fact that the rest
-// of the keyrings API using the _effective_ UID throughout, the translation of
+// of the keyrings API uses the _effective_ UID throughout, the translation of
 // KEY_SPEC_USER_KEYRING is done with respect to the _real_ UID. This means that
 // a simpler implementation would not respect permissions dropping.
 func getUserKeyringID() (int, error) {
@@ -150,10 +150,12 @@ func getUserKeyringID() (int, error) {
 
 func keyringLink(keyID int, keyringID int) error {
 	_, err := unix.KeyctlInt(unix.KEYCTL_LINK, keyID, keyringID, 0, 0)
-	return errors.Wrapf(err, "linking key %d into keyring %d", keyID, keyringID)
+	log.Printf("KeyctlLink(%d, %d) = %v", keyID, keyringID, err)
+	return errors.Wrap(ErrKeyringLink, err.Error())
 }
 
 func keyringUnlink(keyID int, keyringID int) error {
 	_, err := unix.KeyctlInt(unix.KEYCTL_UNLINK, keyID, keyringID, 0, 0)
-	return errors.Wrapf(err, "unlinking key %d from keyring %d", keyID, keyringID)
+	log.Printf("KeyctlUnlink(%d, %d) = %v", keyID, keyringID, err)
+	return errors.Wrap(ErrKeyringUnlink, err.Error())
 }

--- a/security/keyring.go
+++ b/security/keyring.go
@@ -1,0 +1,159 @@
+/*
+ * privileges.go - Handles inserting/removing into user keyrings.
+ *
+ * Copyright 2017 Google Inc.
+ * Author: Joe Richey (joerichey@google.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package security
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// file which lists all visible keys
+	keyListFilename = "/proc/keys"
+	// keyType is always logon as required by filesystem encryption.
+	keyType = "logon"
+)
+
+// FindKey tries to locate a key in the kernel keyring with the provided
+// description. The key id is returned if we can find the key. An error is
+// returned if the key does not exist.
+func FindKey(description string) (int, error) {
+	keyringID, err := getUserKeyringID()
+	if err != nil {
+		return 0, err
+	}
+
+	keyID, err := unix.KeyctlSearch(keyringID, keyType, description, 0)
+	log.Printf("KeyctlSearch(%d, %s, %s) = %d, %v", keyringID, keyType, description, keyID, err)
+	if err != nil {
+		return 0, errors.Wrap(ErrKeyringSearch, err.Error())
+	}
+	return keyID, err
+}
+
+// RemoveKey tries to remove a policy key from the kernel keyring with the
+// provided description. An error is returned if the key does not exist.
+func RemoveKey(description string) error {
+	keyID, err := FindKey(description)
+	if err != nil {
+		return err
+	}
+
+	// We use KEYCTL_INVALIDATE instead of KEYCTL_REVOKE because
+	// invalidating a key immediately removes it.
+	_, err = unix.KeyctlInt(unix.KEYCTL_INVALIDATE, keyID, 0, 0, 0)
+	log.Printf("KeyctlInvalidate(%d) = %v", keyID, err)
+	if err != nil {
+		return errors.Wrap(ErrKeyringDelete, err.Error())
+	}
+	return nil
+}
+
+// InsertKey puts the provided data into the kernel keyring with the provided
+// description.
+func InsertKey(data []byte, description string) error {
+	keyringID, err := getUserKeyringID()
+	if err != nil {
+		return err
+	}
+
+	keyID, err := unix.AddKey(keyType, description, data, keyringID)
+	log.Printf("KeyctlAddKey(%s, %s, <data>, %d) = %d, %v",
+		keyType, description, keyringID, keyID, err)
+	if err != nil {
+		return errors.Wrap(ErrKeyringInsert, err.Error())
+	}
+	return nil
+}
+
+var keyringIDCache = make(map[int]int)
+
+// getUserKeyringID returns the key id of the current user's user keyring. A
+// simpler approach would be to use
+//     unix.KeyctlGetKeyringID(unix.KEY_SPEC_USER_KEYRING, false)
+// which would work in almost all cases. However, despite the fact that the rest
+// of the keyrings API using the _effective_ UID throughout, the translation of
+// KEY_SPEC_USER_KEYRING is done with respect to the _real_ UID. This means that
+// a simpler implementation would not respect permissions dropping.
+func getUserKeyringID() (int, error) {
+	// We will cache the result of this function.
+	euid := unix.Geteuid()
+	if keyringID, ok := keyringIDCache[euid]; ok {
+		return keyringID, nil
+	}
+
+	data, err := ioutil.ReadFile(keyListFilename)
+	if err != nil {
+		log.Print(err)
+		return 0, ErrReadingKeyList
+	}
+
+	expectedName := fmt.Sprintf("_uid.%d:", euid)
+	for _, line := range bytes.Split(data, []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+
+		// Each line in /proc/keys should have 9 columns.
+		columns := bytes.Fields(line)
+		if len(columns) < 9 {
+			return 0, ErrReadingKeyList
+		}
+		hexID := string(columns[0])
+		owner := string(columns[5])
+		name := string(columns[8])
+
+		// Our desired key is owned by the user and has the right name.
+		// The owner check is so another user cannot DOS this user by
+		// inserting a keyring with a similar name.
+		if owner != strconv.Itoa(euid) || name != expectedName {
+			continue
+		}
+
+		// The keyring's ID is encoded as hex.
+		parsedID, err := strconv.ParseInt(hexID, 16, 32)
+		if err != nil {
+			log.Print(err)
+			return 0, ErrReadingKeyList
+		}
+
+		keyringID := int(parsedID)
+		keyringIDCache[euid] = keyringID
+		return keyringID, nil
+	}
+
+	return 0, ErrFindingKeyring
+}
+
+func keyringLink(keyID int, keyringID int) error {
+	_, err := unix.KeyctlInt(unix.KEYCTL_LINK, keyID, keyringID, 0, 0)
+	return errors.Wrapf(err, "linking key %d into keyring %d", keyID, keyringID)
+}
+
+func keyringUnlink(keyID int, keyringID int) error {
+	_, err := unix.KeyctlInt(unix.KEYCTL_UNLINK, keyID, keyringID, 0, 0)
+	return errors.Wrapf(err, "unlinking key %d from keyring %d", keyID, keyringID)
+}

--- a/security/privileges.go
+++ b/security/privileges.go
@@ -1,0 +1,120 @@
+/*
+ * privileges.go - Handles raising and dropping user privileges.
+ *
+ * Copyright 2017 Google Inc.
+ * Author: Joe Richey (joerichey@google.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+// Package security manages:
+//  - Keyring Operations (keyring.go)
+//  - Privilege manipulation (privileges.go)
+//  - Maintaining the link between the root and user keyrings.
+package security
+
+import (
+	"log"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
+	"github.com/google/fscrypt/util"
+)
+
+// Package security error values
+var (
+	ErrReadingKeyList = util.SystemError("could not read keys from " + keyListFilename)
+	ErrFindingKeyring = util.SystemError("could not find user keyring")
+	ErrKeyringInsert  = util.SystemError("could not insert key into the keyring")
+	ErrKeyringSearch  = errors.New("could not find key with descriptor")
+	ErrKeyringDelete  = util.SystemError("could not delete key from the keyring")
+)
+
+// Privileges contains the state needed to restore a user's original privileges.
+type Privileges struct {
+	euid   int
+	egid   int
+	groups []int
+}
+
+// DropThreadPrivileges temporarily drops the privileges of the current thread
+// to have the euid and egid specified. The returned opaque Privileges structure
+// should later be passed to RestoreThreadPrivileges.
+// Due to golang/go#1435, these privileges are only dropped for a single thread.
+// This function also makes sure that the appropriate user keyrings are linked.
+// This ensures that the user's keys are visible from commands like sudo.
+func DropThreadPrivileges(euid int, egid int) (*Privileges, error) {
+	var err error
+	privs := &Privileges{
+		euid: unix.Geteuid(),
+		egid: unix.Getegid(),
+	}
+	if privs.groups, err = unix.Getgroups(); err != nil {
+		return nil, errors.Wrapf(err, "getting groups")
+	}
+
+	// We link the privileged keyring into the thread keyring so that we
+	// can still modify it after dropping privileges.
+	privilegedUserKeyringID, err := getUserKeyringID()
+	if err != nil {
+		return nil, err
+	}
+	if err = keyringLink(privilegedUserKeyringID, unix.KEY_SPEC_THREAD_KEYRING); err != nil {
+		return nil, err
+	}
+	defer keyringUnlink(privilegedUserKeyringID, unix.KEY_SPEC_THREAD_KEYRING)
+
+	// Drop euid last so we have permissions to drop the others.
+	if err = unix.Setregid(-1, egid); err != nil {
+		return nil, errors.Wrapf(err, "dropping egid to %d", egid)
+	}
+	if err = unix.Setgroups([]int{egid}); err != nil {
+		return nil, errors.Wrapf(err, "dropping groups")
+	}
+	if err = unix.Setreuid(-1, euid); err != nil {
+		return nil, errors.Wrapf(err, "dropping euid to %d", euid)
+	}
+	log.Printf("privileges dropped to euid=%d, egid=%d", euid, egid)
+
+	// If the link already exists, this linking does nothing and succeeds.
+	droppedUserKeyringID, err := getUserKeyringID()
+	if err != nil {
+		return nil, err
+	}
+	if err = keyringLink(droppedUserKeyringID, privilegedUserKeyringID); err != nil {
+		return nil, err
+	}
+	log.Printf("user keyring (%d) linked into root user keyring (%d)",
+		droppedUserKeyringID, privilegedUserKeyringID)
+
+	return privs, nil
+}
+
+// RaiseThreadPrivileges returns the state of a threads privileges to what it
+// was before the call to DropThreadPrivileges.
+func RaiseThreadPrivileges(privs *Privileges) error {
+	// Raise euid last so we have permissions to raise the others.
+	if err := unix.Setreuid(-1, privs.euid); err != nil {
+		return errors.Wrapf(err, "raising euid to %d", privs.euid)
+	}
+	if err := unix.Setregid(-1, privs.egid); err != nil {
+		return errors.Wrapf(err, "raising egid to %d", privs.egid)
+	}
+	if err := unix.Setgroups(privs.groups); err != nil {
+		return errors.Wrapf(err, "raising groups")
+	}
+
+	log.Printf("privileges raised to euid=%d, egid=%d", privs.euid, privs.egid)
+	return nil
+}

--- a/util/util.go
+++ b/util/util.go
@@ -25,6 +25,7 @@ package util
 
 import (
 	"bufio"
+	"log"
 	"math"
 	"os"
 	"unsafe"
@@ -96,4 +97,20 @@ func ReadLine() (string, error) {
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	return scanner.Text(), scanner.Err()
+}
+
+// DropInodeCache instructs the kernel to clear the global cache of inodes and
+// dentries. This has the effect of making encrypted directories whose keys
+// are not present no longer accessible. Requires root privileges.
+func DropInodeCache() error {
+	log.Print("dropping page caches")
+	// See: https://www.kernel.org/doc/Documentation/sysctl/vm.txt
+	file, err := os.OpenFile("/proc/sys/vm/drop_caches", os.O_WRONLY|os.O_SYNC, 0)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	// "2" just clears the inodes and dentries
+	_, err = file.WriteString("2")
+	return err
 }


### PR DESCRIPTION
Fixes #35 

This PR also does some general cleanup by separating things like privilege dropping and keyring management to a separate `security` package. 

As part of this cleanup,  the `(Drop/Raise)ThreadPrivileges` functions are added. These also serve to make sure the correct keyrings are linked. These will also be used with the PAM module (see #4)