### PR TITLE
Use `/dev/disk/by-uuid` to get UUID links to other filesystems 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
       - sourceline: 'deb http://en.archive.ubuntu.com/ubuntu/ artful main universe'
     packages:
       - libargon2-0-dev
-      - libblkid-dev
       - libpam0g-dev
       - e2fsprogs
       - protobuf-compiler

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,9 @@ endif
 #		builds the C code with high optimizations, and C warnings fail.
 #	LDFLAGS
 #		Change the flags passed to the C linker. Empty by default.
-#		For example:
-#			make fscrypt "LDFLAGS = -static -luuid -ldl -laudit -lpthread"
-#		will build a static binary.
+#		For example (on my system with additional dev packages):
+#			make fscrypt "LDFLAGS = -static -ldl -laudit -lcap-ng"
+#		will build a static fscrypt binary.
 #	GO_FLAGS
 #		Change the flags passed to "go build". Empty by default.
 #		For example:
@@ -179,8 +179,6 @@ test-setup:
 	sudo mkdir -p $(MOUNT)
 	sudo mount -o rw,loop $(IMAGE) $(MOUNT)
 	sudo chmod +777 $(MOUNT)
-	# Add UUID to BLKID cache
-	sudo blkid $$(df $(MOUNT) --output=source | grep /dev/)
 
 test-teardown:
 	sudo umount $(MOUNT)

--- a/README.md
+++ b/README.md
@@ -119,11 +119,10 @@ fscrypt has the following build dependencies:
     >>>>> make
     >>>>> sudo make install
     ```
-*   Headers for `libblkid` and `libpam`. These can be installed with the
-    appropriate package manager.
-    - `sudo apt-get install libblkid-dev libpam0g-dev`
-    - `sudo yum install libblkid-devel pam-devel`
-    - `pam` and `util-liux` packages for Arch
+*   Headers for `libpam`. Install them with the appropriate package manager.
+    - `sudo apt-get install libpam0g-dev`
+    - `sudo yum install pam-devel`
+    - `pam` package for Arch (part of the `base` group)
 
 Once all the dependencies are installed, you can get the repository by running:
 ```shell
@@ -149,8 +148,7 @@ fscrypt has the following runtime dependencies:
 *   Kernel support for filesystem encryption (this will depend on your kernel
     configuration and specific filesystem)
 *   `libargon2.so` (see the above installation instructions for Argon2)
-*   `libblkid.so` and `libpam.so`. These libraries are almost certainly already
-    on your system.
+*   `libpam.so` (almost certainly already on your system)
 
 The dynamic libraries are not needed if you built a static executable.
 

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -84,9 +84,7 @@ var (
 // There is also the ability to reference another filesystem's metadata. This is
 // used when a Policy on filesystem A is protected with Protector on filesystem
 // B. In this scenario, we store a "link file" in the protectors directory whose
-// contents look like "UUID=3a6d9a76-47f0-4f13-81bf-3332fbe984fb". These
-// contents can be anything parsable by libblkid (i.e. anything that could be in
-// the Device column of /etc/fstab).
+// contents look like "UUID=3a6d9a76-47f0-4f13-81bf-3332fbe984fb".
 type Mount struct {
 	Path       string
 	Filesystem string


### PR DESCRIPTION
This fixes #50 which showed how the libblkid cache is sometimes missing certain entries, making it impossible to create a filesystem link for an unprivileged user.

This PR removes the entire dependency on `libblkid` and `libuuid`. Now, a search of `/dev/disk/by-uuid` is done to find the appropriate UUID. This takes a dependency on certain _default_ udev configs, but only for creating filesystem links. The rest of fscrypt will work without the dependency.