### PR TITLE
Fixed failures in PAM module

### DIFF
--- a/actions/policy.go
+++ b/actions/policy.go
@@ -60,7 +60,7 @@ func PurgeAllPolicies(ctx *Context) error {
 		err = security.RemoveKey(service+policyDescriptor, ctx.TargetUser)
 
 		switch errors.Cause(err) {
-		case nil, security.ErrKeyringSearch:
+		case nil, security.ErrKeySearch:
 			// We don't care if the key has already been removed
 		default:
 			return err

--- a/cmd/fscrypt/commands.go
+++ b/cmd/fscrypt/commands.go
@@ -119,7 +119,7 @@ func encryptAction(c *cli.Context) error {
 // keyring unless --skip-unlock is used. On failure, an error is returned, any
 // metadata creation is reverted, and the directory is unmodified.
 func encryptPath(path string) (err error) {
-	target, err := parseUserFlag()
+	target, err := parseUserFlag(!skipUnlockFlag.Value)
 	if err != nil {
 		return
 	}
@@ -274,7 +274,7 @@ func unlockAction(c *cli.Context) error {
 		return expectedArgsErr(c, 1, false)
 	}
 
-	target, err := parseUserFlag()
+	target, err := parseUserFlag(true)
 	if err != nil {
 		return newExitError(c, err)
 	}
@@ -357,7 +357,7 @@ func purgeAction(c *cli.Context) error {
 		}
 	}
 
-	target, err := parseUserFlag()
+	target, err := parseUserFlag(true)
 	if err != nil {
 		return newExitError(c, err)
 	}
@@ -507,7 +507,7 @@ func createProtectorAction(c *cli.Context) error {
 		return expectedArgsErr(c, 1, false)
 	}
 
-	target, err := parseUserFlag()
+	target, err := parseUserFlag(false)
 	if err != nil {
 		return newExitError(c, err)
 	}

--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -35,6 +35,7 @@ import (
 	"github.com/google/fscrypt/crypto"
 	"github.com/google/fscrypt/filesystem"
 	"github.com/google/fscrypt/metadata"
+	"github.com/google/fscrypt/security"
 	"github.com/google/fscrypt/util"
 )
 
@@ -93,6 +94,14 @@ func getErrorSuggestions(err error) string {
 			needs to be enabled for this filesystem. See the
 			documentation on how to enable encryption on ext4
 			systems (and the risks of doing so).`
+	case security.ErrSessionUserKeying:
+		return `This is usually the result of a bad PAM configuration.
+			Either correct the problem in your PAM stack, enable
+			pam_keyinit.so, or run "keyctl link @u @s".`
+	case security.ErrAccessUserKeyring:
+		return fmt.Sprintf(`You can only use %s to access the user
+			keyring of another user if you are running as root.`,
+			shortDisplay(userFlag))
 	case actions.ErrBadConfigFile:
 		return `Run "sudo fscrypt setup" to recreate the file.`
 	case actions.ErrNoConfigFile:

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -134,14 +134,14 @@ func (h *Handle) StartAsPamUser() error {
 	if err := security.KeyringsSetup(h.PamUser, h.OrigUser); err != nil {
 		return err
 	}
-	return security.SetThreadPrivileges(h.PamUser, false)
+	return security.SetThreadPrivileges(h.PamUser)
 }
 
 // StopAsPamUser restores the original privileges that were running the
 // PAM module (this is usually root). As this error is often ignored in a defer
 // statement, any error is also logged.
 func (h *Handle) StopAsPamUser() error {
-	err := security.SetThreadPrivileges(h.OrigUser, false)
+	err := security.SetThreadPrivileges(h.OrigUser)
 	if err != nil {
 		log.Print(err)
 	}

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -131,8 +131,8 @@ func (h *Handle) GetItem(i Item) (unsafe.Pointer, error) {
 // StartAsPamUser sets the effective privileges to that of the PAM user, and
 // configures the PAM user's keyrings to be properly linked.
 func (h *Handle) StartAsPamUser() error {
-	if err := security.KeyringsSetup(h.PamUser, h.OrigUser); err != nil {
-		return err
+	if _, err := security.UserKeyringID(h.PamUser); err != nil {
+		log.Printf("Setting up keyrings in PAM: %v", err)
 	}
 	return security.SetThreadPrivileges(h.PamUser)
 }


### PR DESCRIPTION
This PR stops certain functionality from failing in the PAM module. This is mainly done by changing how we lookup the user keyring. We no longer user goroutines, which were part of the problem.

The PAM functions are now (mostly) insulated against panics making them crash. This fixes #53 