### PR TITLE
security: Add check option to UserKeyringID

### DIFF
--- a/cmd/fscrypt/flags.go
+++ b/cmd/fscrypt/flags.go
@@ -300,7 +300,7 @@ func parseUserFlag(checkKeyring bool) (targetUser *user.User, err error) {
 	}
 
 	if checkKeyring {
-		_, err = security.UserKeyringID(targetUser)
+		_, err = security.UserKeyringID(targetUser, true)
 	}
 	return targetUser, err
 }

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -131,7 +131,7 @@ func (h *Handle) GetItem(i Item) (unsafe.Pointer, error) {
 // StartAsPamUser sets the effective privileges to that of the PAM user, and
 // configures the PAM user's keyrings to be properly linked.
 func (h *Handle) StartAsPamUser() error {
-	if _, err := security.UserKeyringID(h.PamUser); err != nil {
+	if _, err := security.UserKeyringID(h.PamUser, true); err != nil {
 		log.Printf("Setting up keyrings in PAM: %v", err)
 	}
 	return security.SetThreadPrivileges(h.PamUser)

--- a/security/keyring.go
+++ b/security/keyring.go
@@ -105,9 +105,9 @@ var (
 // UserKeyringID returns the key id of the target user's user keyring. We also
 // ensure that the keyring will be accessible by linking it into the process
 // keyring and linking it into the root user keyring (permissions allowing). If
-// check_session is true, an error is returned if a normal user requests their
+// checkSession is true, an error is returned if a normal user requests their
 // user keyring, but it is not in the current session keyring.
-func UserKeyringID(target *user.User, check_session bool) (int, error) {
+func UserKeyringID(target *user.User, checkSession bool) (int, error) {
 	uid := util.AtoiOrPanic(target.Uid)
 	targetKeyring, err := userKeyringIDLookup(uid)
 	if err != nil {
@@ -117,7 +117,7 @@ func UserKeyringID(target *user.User, check_session bool) (int, error) {
 	if !util.IsUserRoot() {
 		// Make sure the returned keyring will be accessible by checking
 		// that it is in the session keyring.
-		if check_session && !isUserKeyringInSession(uid) {
+		if checkSession && !isUserKeyringInSession(uid) {
 			return 0, ErrSessionUserKeying
 		}
 		return targetKeyring, nil

--- a/security/keyring.go
+++ b/security/keyring.go
@@ -49,7 +49,7 @@ var (
 // description. The key ID is returned if we can find the key. An error is
 // returned if the key does not exist.
 func FindKey(description string, target *user.User) (int, error) {
-	keyringID, err := UserKeyringID(target)
+	keyringID, err := UserKeyringID(target, false)
 	if err != nil {
 		return 0, err
 	}
@@ -83,7 +83,7 @@ func RemoveKey(description string, target *user.User) error {
 // InsertKey puts the provided data into the kernel keyring with the provided
 // description.
 func InsertKey(data []byte, description string, target *user.User) error {
-	keyringID, err := UserKeyringID(target)
+	keyringID, err := UserKeyringID(target, true)
 	if err != nil {
 		return err
 	}
@@ -104,10 +104,10 @@ var (
 
 // UserKeyringID returns the key id of the target user's user keyring. We also
 // ensure that the keyring will be accessible by linking it into the process
-// keyring and linking it into the root user keyring (permissions allowing). An
-// error is returned if a normal user requests their user keyring, but it is not
-// in the current session keyring.
-func UserKeyringID(target *user.User) (int, error) {
+// keyring and linking it into the root user keyring (permissions allowing). If
+// check_session is true, an error is returned if a normal user requests their
+// user keyring, but it is not in the current session keyring.
+func UserKeyringID(target *user.User, check_session bool) (int, error) {
 	uid := util.AtoiOrPanic(target.Uid)
 	targetKeyring, err := userKeyringIDLookup(uid)
 	if err != nil {
@@ -117,7 +117,7 @@ func UserKeyringID(target *user.User) (int, error) {
 	if !util.IsUserRoot() {
 		// Make sure the returned keyring will be accessible by checking
 		// that it is in the session keyring.
-		if !isUserKeyringInSession(uid) {
+		if check_session && !isUserKeyringInSession(uid) {
 			return 0, ErrSessionUserKeying
 		}
 		return targetKeyring, nil


### PR DESCRIPTION
This means the "user keyring in session keyring" invariant will not be checked when searching for or removing a key. 

Fixes #57 (hopefully)