### PR TITLE
Minor fixes and cleanup

### DIFF
--- a/actions/protector.go
+++ b/actions/protector.go
@@ -123,7 +123,7 @@ func CreateProtector(ctx *Context, name string, keyFn KeyFunc) (*Protector, erro
 		// UID for this kind of source.
 		protector.data.Uid = int64(util.AtoiOrPanic(ctx.TargetUser.Uid))
 		// Make sure we aren't duplicating protectors
-		if err := checkIfUserHasLoginProtector(ctx, protector.data.Uid); err != nil {
+		if err = checkIfUserHasLoginProtector(ctx, protector.data.Uid); err != nil {
 			return nil, err
 		}
 		fallthrough
@@ -142,7 +142,7 @@ func CreateProtector(ctx *Context, name string, keyFn KeyFunc) (*Protector, erro
 	}
 	protector.data.ProtectorDescriptor = crypto.ComputeDescriptor(protector.key)
 
-	if err := protector.Rewrap(keyFn); err != nil {
+	if err = protector.Rewrap(keyFn); err != nil {
 		protector.Lock()
 		return nil, err
 	}

--- a/cmd/fscrypt/commands.go
+++ b/cmd/fscrypt/commands.go
@@ -519,7 +519,7 @@ func createProtectorAction(c *cli.Context) error {
 	}
 
 	prompt := fmt.Sprintf("Create new protector on %q", ctx.Mount.Path)
-	if err := askConfirmation(prompt, true, ""); err != nil {
+	if err = askConfirmation(prompt, true, ""); err != nil {
 		return newExitError(c, err)
 	}
 
@@ -561,20 +561,20 @@ func createPolicyAction(c *cli.Context) error {
 		return newExitError(c, err)
 	}
 
-	if err := checkRequiredFlags(c, []*stringFlag{protectorFlag}); err != nil {
+	if err = checkRequiredFlags(c, []*stringFlag{protectorFlag}); err != nil {
 		return err
 	}
 	protector, err := getProtectorFromFlag(protectorFlag.Value, ctx.TargetUser)
 	if err != nil {
 		return newExitError(c, err)
 	}
-	if err := protector.Unlock(existingKeyFn); err != nil {
+	if err = protector.Unlock(existingKeyFn); err != nil {
 		return newExitError(c, err)
 	}
 	defer protector.Lock()
 
 	prompt := fmt.Sprintf("Create new policy on %q", ctx.Mount.Path)
-	if err := askConfirmation(prompt, true, ""); err != nil {
+	if err = askConfirmation(prompt, true, ""); err != nil {
 		return newExitError(c, err)
 	}
 

--- a/cmd/fscrypt/strings.go
+++ b/cmd/fscrypt/strings.go
@@ -110,7 +110,7 @@ Options:
 {{if .Version}}Version:
 ` + indent + `{{.Version}}
 
-{{end}}{{if .Compiled}}Compiled:
+{{end}}{{if not .Compiled.IsZero}}Compiled:
 ` + indent + `{{.Compiled}}
 
 {{end}}{{if len .Authors}}Author{{with $length := len .Authors}}{{if ne 1 $length}}s{{end}}{{end}}:{{range .Authors}}

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -333,7 +333,7 @@ func ReadRecoveryCode(reader io.Reader) (*Key, error) {
 	for blockStart := blockSize; blockStart < encodedLength; blockStart += blockSize {
 		r.Read(inputSeparator)
 		if r.Err() == nil && !bytes.Equal(separator, inputSeparator) {
-			err := errors.Wrapf(ErrRecoveryCode, "invalid separator %q", inputSeparator)
+			err = errors.Wrapf(ErrRecoveryCode, "invalid separator %q", inputSeparator)
 			return nil, err
 		}
 

--- a/metadata/policy.go
+++ b/metadata/policy.go
@@ -86,7 +86,7 @@ func GetPolicy(path string) (*PolicyData, error) {
 	defer file.Close()
 
 	var policy unix.FscryptPolicy
-	if err := policyIoctl(file, unix.FS_IOC_GET_ENCRYPTION_POLICY, &policy); err != nil {
+	if err = policyIoctl(file, unix.FS_IOC_GET_ENCRYPTION_POLICY, &policy); err != nil {
 		return nil, errors.Wrapf(err, "get encryption policy %s", path)
 	}
 
@@ -119,7 +119,7 @@ func SetPolicy(path string, data *PolicyData) error {
 	}
 	defer file.Close()
 
-	if err := data.CheckValidity(); err != nil {
+	if err = data.CheckValidity(); err != nil {
 		return errors.Wrap(err, "invalid policy")
 	}
 

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -58,7 +58,7 @@ func NewHandle(pamh unsafe.Pointer) (*Handle, error) {
 
 	var pamUsername *C.char
 	h.status = C.pam_get_user(h.handle, &pamUsername, nil)
-	if err := h.err(); err != nil {
+	if err = h.err(); err != nil {
 		return nil, err
 	}
 

--- a/pam_fscrypt/run_fscrypt.go
+++ b/pam_fscrypt/run_fscrypt.go
@@ -199,7 +199,7 @@ func AdjustCount(handle *pam.Handle, delta int) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+	if err = unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
 		return 0, err
 	}
 	defer file.Close()


### PR DESCRIPTION
Fixes an issue where if fscrypt was built with `go build github.com/google/fscrypt/cmd/fscrypt`, the `Compiled:` line in `fscrypt --version` would still appear (as the zero value for a date is still a valid date).

This also uses `go vet -shadow ./...` to find cases where we are using shadowing incorrectly. It still gives some false positives, but it did find a few problems.