### PR TITLE
pam: return error when PAM info item is unset

### DIFF
--- a/pam/pam.go
+++ b/pam/pam.go
@@ -120,12 +120,18 @@ func (h *Handle) GetString(name string) (string, error) {
 	return C.GoString((*C.char)(data)), nil
 }
 
-// GetItem retrieves a PAM information item. This a pointer directory to the
+// GetItem retrieves a PAM information item. This is a pointer directly to the
 // data, so it shouldn't be modified.
 func (h *Handle) GetItem(i Item) (unsafe.Pointer, error) {
 	var data unsafe.Pointer
 	h.status = C.pam_get_item(h.handle, C.int(i), &data)
-	return data, h.err()
+	if err := h.err(); err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, errors.New("item not found")
+	}
+	return data, nil
 }
 
 // StartAsPamUser sets the effective privileges to that of the PAM user, and


### PR DESCRIPTION
pam_fscrypt is crashing with a segfault in copyIntoSecret() when using
Ctrl-C to interrupt a 'sudo' prompt.  It is dereferencing a NULL pointer
that is supposed point to the PAM_AUTHTOK item.  The problem is that the
Go code assumes pam_get_item() returns a non-success status if the item
is unset, when actually it sets the data pointer to NULL and returns
PAM_SUCCESS.

Fix it by making pam.Handle.GetItem() return an error in that case.