### PR TITLE
Use proper sizes when casting to Go slice

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -25,7 +25,6 @@ package util
 
 import (
 	"bufio"
-	"math"
 	"os"
 	"os/user"
 	"strconv"
@@ -43,15 +42,15 @@ func Ptr(slice []byte) unsafe.Pointer {
 // ByteSlice takes a pointer to some data and views it as a slice of bytes.
 // Note, indexing into this slice is unsafe.
 func ByteSlice(ptr unsafe.Pointer) []byte {
-	// Silce must fix in 32-bit address space to build on 32-bit platforms.
-	return (*[math.MaxInt32]byte)(ptr)[:]
+	// Silce must fit in the smallest address space go suppports.
+	return (*[1 << 30]byte)(ptr)[:]
 }
 
 // PointerSlice takes a pointer to an array of pointers and views it as a slice
 // of pointers. Note, indexing into this slice is unsafe.
 func PointerSlice(ptr unsafe.Pointer) []unsafe.Pointer {
-	// Silce must fix in 32-bit address space to build on 32-bit platforms.
-	return (*[math.MaxInt32 / 4]unsafe.Pointer)(ptr)[:]
+	// Silce must fit in the smallest address space go suppports.
+	return (*[1 << 28]unsafe.Pointer)(ptr)[:]
 }
 
 // Index returns the first index i such that inVal == inArray[i].


### PR DESCRIPTION
Addresses most of the issues in #101.

The following commands now succeed:
    GOARCH=mips go build github.com/google/fscrypt/util
    GOARCH=mipsle go build github.com/google/fscrypt/util