### PR TITLE
Fix Travis to only use Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 dist: trusty
-go: 1.9.x
+go: 1.10.x
 
 notifications:
   email: false
@@ -40,8 +40,6 @@ jobs:
       script:
         - go build github.com/google/fscrypt/cmd/fscrypt
         - make
-    - <<: *build
-      go: 1.8.x
 
     - env: Integration Tests
       sudo: required

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ information about each of the commands.
 ## Building and Installing
 
 fscrypt has a minimal set of build dependencies:
-*   [Go](https://golang.org/doc/install)
+*   [Go](https://golang.org/doc/install) 1.10 or higher
 *   A C compiler (`gcc` or `clang`)
 *   `make`
 *   Headers for [`libpam`](http://www.linux-pam.org/).


### PR DESCRIPTION
We want to use some of the `cgo` improvements in 1.10 that will simplify our code.