### PR TITLE
Install pam modules/configs to the right location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ bin/goimports
 bin/staticcheck
 bin/gocovmerge
 bin/misspell
+bin/config
 *coverage.out
 .vscode

--- a/README.md
+++ b/README.md
@@ -121,13 +121,14 @@ Once all the dependencies are installed, you can get the repository by running:
 go get -d github.com/google/fscrypt/...
 ```
 Running `make` in `$GOPATH/src/github.com/google/fscrypt` builds the
-executable (`fscrypt`) and PAM module (`pam-fscrypt.so`) in the `bin/`
+executable (`fscrypt`) and PAM module (`pam_fscrypt.so`) in the `bin/`
 directory. Use `make bin/fscrypt` or `make bin/pam_fscrypt.so`
 to build only one.
 
-Running `sudo make install` installs `fscrypt` to `/usr/local/bin` and
-`pam-fscrypt` to `/lib/security`. Use `make install-bin` or `make install-pam`
-to install only one.
+Running `sudo make install` installs `fscrypt` to `/usr/local/bin`,
+`pam_fscrypt.so` to `/usr/local/lib/security`, and `pam_fscrypt/config` to
+`/usr/local/share/pam-configs`. Use `make install-bin` to only install
+`fscrypt`. Use `make install-pam` to only install the pam files.
 
 See the `Makefile` for instructions on how to customize the build (e.g. installing
 to a custom location, using different build flags, building a static binary,

--- a/pam_fscrypt/config
+++ b/pam_fscrypt/config
@@ -3,11 +3,11 @@ Default: yes
 Priority: 0
 Auth-Type: Additional
 Auth-Final:
-	optional	pam_fscrypt.so
+	optional	PAM_INSTALL_PATH
 Session-Type: Additional
 Session-Interactive-Only: yes
 Session-Final:
-	optional	pam_fscrypt.so drop_caches lock_policies
+	optional	PAM_INSTALL_PATH drop_caches lock_policies
 Password-Type: Additional
 Password-Final:
-	optional	pam_fscrypt.so
+	optional	PAM_INSTALL_PATH


### PR DESCRIPTION
Per the [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard), manually installed programs should go under `/usr/local`.
This change also makes it easier to change the global installation
prefix. For example, package managers should set `PREFIX=/usr`