### PR TITLE
Fix 'make format'-related CI failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ override GO_FLAGS += --ldflags '$(GO_LINK_FLAGS)'
 ###### Find All Files and Directories ######
 FILES := $(shell find . \( -path ./vendor -o -path "./.*" \) -prune -o -type f -printf "%P\n")
 GO_FILES := $(filter %.go,$(FILES))
+GO_NONGEN_FILES := $(filter-out %.pb.go,$(GO_FILES))
 GO_DIRS := $(sort $(dir $(GO_FILES)))
 C_FILES := $(filter %.c %.h,$(FILES))
 PROTO_FILES := $(filter %.proto,$(FILES))
@@ -95,7 +96,7 @@ gen: $(BIN)/protoc $(BIN)/protoc-gen-go $(PROTO_FILES)
 	protoc --go_out=. $(PROTO_FILES)
 
 format: $(BIN)/goimports
-	goimports -w $(GO_DIRS)
+	goimports -w $(GO_NONGEN_FILES)
 	clang-format -i -style=Google $(C_FILES)
 
 lint: $(BIN)/golint $(BIN)/staticcheck $(BIN)/misspell

--- a/filesystem/mountpoint.go
+++ b/filesystem/mountpoint.go
@@ -22,8 +22,16 @@
 package filesystem
 
 import (
+	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
 )
 
 /*
@@ -34,17 +42,6 @@ const char* mountpoints_filename = "/proc/mounts";
 const char* read_mode = "r";
 */
 import "C"
-
-import (
-	"fmt"
-	"log"
-	"path/filepath"
-	"sort"
-	"strings"
-	"sync"
-
-	"github.com/pkg/errors"
-)
 
 var (
 	// These maps hold data about the state of the system's mountpoints.


### PR DESCRIPTION
* Exclude generated files from 'make format'
* Run 'make format' with latest version of goimports

