### PR TITLE
.gitignore: add tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin/misspell
 bin/config
 *coverage.out
 .vscode
+tags


### PR DESCRIPTION
Add the tags file to .gitignore, for developers using
https://github.com/jstemmer/gotags.