### PR TITLE
cmd/fscrypt: show encryption options with 'fscrypt status DIR'

### DIFF
--- a/actions/policy.go
+++ b/actions/policy.go
@@ -194,6 +194,11 @@ func (policy *Policy) Description() string {
 	return policy.Context.getService() + policy.Descriptor()
 }
 
+// Options returns the encryption options of this policy.
+func (policy *Policy) Options() *metadata.EncryptionOptions {
+	return policy.data.Options
+}
+
 // Destroy removes a policy from the filesystem. The internal key should still
 // be wiped with Lock().
 func (policy *Policy) Destroy() error {

--- a/cmd/fscrypt/status.go
+++ b/cmd/fscrypt/status.go
@@ -178,6 +178,7 @@ func writePathStatus(w io.Writer, path string) error {
 	fmt.Fprintf(w, "%q is encrypted with fscrypt.\n", path)
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "Policy:   %s\n", policy.Descriptor())
+	fmt.Fprintf(w, "Options:  %s\n", policy.Options())
 	fmt.Fprintf(w, "Unlocked: %s\n", yesNoString(policy.IsProvisioned()))
 	fmt.Fprintln(w)
 


### PR DESCRIPTION
Show the encryption options when running 'fscrypt status' on a
directory.  E.g.:

	Policy:   490515286453d3f7
	Options:  padding:32 contents:Adiantum filenames:Adiantum
	Unlocked: Yes