### PR TITLE
filesystem: allow .fscrypt to be a symlink

### DIFF
--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -20,6 +20,7 @@
 package filesystem
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -107,6 +108,68 @@ func TestRemoveAllMetadata(t *testing.T) {
 	if isDir(mnt.BaseDir()) {
 		t.Error("metadata was not removed")
 	}
+}
+
+// Test that when MOUNTPOINT/.fscrypt is a pre-created symlink, fscrypt will
+// create/delete the metadata at the location pointed to by the symlink.
+//
+// This is a helper function that is called twice: once to test an absolute
+// symlink and once to test a relative symlink.
+func testSetupWithSymlink(t *testing.T, mnt *Mount, symlinkTarget string, realDir string) {
+	rawBaseDir := filepath.Join(mnt.Path, baseDirName)
+	if err := os.Symlink(symlinkTarget, rawBaseDir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(rawBaseDir)
+
+	if err := mnt.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	defer mnt.RemoveAllMetadata()
+	if err := mnt.CheckSetup(); err != nil {
+		t.Fatal(err)
+	}
+	if !isSymlink(rawBaseDir) {
+		t.Fatal("base dir should still be a symlink")
+	}
+	if !isDir(realDir) {
+		t.Fatal("real base dir should exist")
+	}
+	if err := mnt.RemoveAllMetadata(); err != nil {
+		t.Fatal(err)
+	}
+	if !isSymlink(rawBaseDir) {
+		t.Fatal("base dir should still be a symlink")
+	}
+	if isDir(realDir) {
+		t.Fatal("real base dir should no longer exist")
+	}
+}
+
+func TestSetupWithAbsoluteSymlink(t *testing.T) {
+	mnt, err := getTestMount(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tempDir, err := ioutil.TempDir("", "fscrypt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+	realDir := filepath.Join(tempDir, "realDir")
+	if realDir, err = filepath.Abs(realDir); err != nil {
+		t.Fatal(err)
+	}
+	testSetupWithSymlink(t, mnt, realDir, realDir)
+}
+
+func TestSetupWithRelativeSymlink(t *testing.T) {
+	mnt, err := getTestMount(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	realDir := filepath.Join(mnt.Path, ".fscrypt-real")
+	testSetupWithSymlink(t, mnt, ".fscrypt-real", realDir)
 }
 
 // Adding a good Protector should succeed, adding a bad one should fail

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -21,6 +21,7 @@ package filesystem
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -108,6 +109,22 @@ func TestRemoveAllMetadata(t *testing.T) {
 	if isDir(mnt.BaseDir()) {
 		t.Error("metadata was not removed")
 	}
+}
+
+// loggedLstat runs os.Lstat (doesn't dereference trailing symlink), but it logs
+// the error if lstat returns any error other than nil or IsNotExist.
+func loggedLstat(name string) (os.FileInfo, error) {
+	info, err := os.Lstat(name)
+	if err != nil && !os.IsNotExist(err) {
+		log.Print(err)
+	}
+	return info, err
+}
+
+// isSymlink returns true if the path exists and is that of a symlink.
+func isSymlink(path string) bool {
+	info, err := loggedLstat(path)
+	return err == nil && info.Mode()&os.ModeSymlink != 0
 }
 
 // Test that when MOUNTPOINT/.fscrypt is a pre-created symlink, fscrypt will

--- a/filesystem/path.go
+++ b/filesystem/path.go
@@ -56,6 +56,16 @@ func loggedStat(name string) (os.FileInfo, error) {
 	return info, err
 }
 
+// loggedLstat runs os.Lstat (doesn't dereference trailing symlink), but it logs
+// the error if lstat returns any error other than nil or IsNotExist.
+func loggedLstat(name string) (os.FileInfo, error) {
+	info, err := os.Lstat(name)
+	if err != nil && !os.IsNotExist(err) {
+		log.Print(err)
+	}
+	return info, err
+}
+
 // isDir returns true if the path exists and is that of a directory.
 func isDir(path string) bool {
 	info, err := loggedStat(path)
@@ -66,6 +76,12 @@ func isDir(path string) bool {
 func isDevice(path string) bool {
 	info, err := loggedStat(path)
 	return err == nil && info.Mode()&os.ModeDevice != 0
+}
+
+// isSymlink returns true if the path exists and is that of a symlink.
+func isSymlink(path string) bool {
+	info, err := loggedLstat(path)
+	return err == nil && info.Mode()&os.ModeSymlink != 0
 }
 
 // isDirCheckPerm returns true if the path exists and is a directory. If the

--- a/filesystem/path.go
+++ b/filesystem/path.go
@@ -56,16 +56,6 @@ func loggedStat(name string) (os.FileInfo, error) {
 	return info, err
 }
 
-// loggedLstat runs os.Lstat (doesn't dereference trailing symlink), but it logs
-// the error if lstat returns any error other than nil or IsNotExist.
-func loggedLstat(name string) (os.FileInfo, error) {
-	info, err := os.Lstat(name)
-	if err != nil && !os.IsNotExist(err) {
-		log.Print(err)
-	}
-	return info, err
-}
-
 // isDir returns true if the path exists and is that of a directory.
 func isDir(path string) bool {
 	info, err := loggedStat(path)
@@ -76,12 +66,6 @@ func isDir(path string) bool {
 func isDevice(path string) bool {
 	info, err := loggedStat(path)
 	return err == nil && info.Mode()&os.ModeDevice != 0
-}
-
-// isSymlink returns true if the path exists and is that of a symlink.
-func isSymlink(path string) bool {
-	info, err := loggedLstat(path)
-	return err == nil && info.Mode()&os.ModeSymlink != 0
 }
 
 // isDirCheckPerm returns true if the path exists and is a directory. If the


### PR DESCRIPTION
Support the case where the user has a read-only root filesystem (e.g.
with OSTree) and had previously created a symlink /.fscrypt pointing to
a writable location, so that login protectors can be created there.

Resolves https://github.com/google/fscrypt/issues/131