### PR TITLE
Handle bind mounts correctly, and other mount-related improvements

### DIFF
--- a/actions/context.go
+++ b/actions/context.go
@@ -78,7 +78,7 @@ func NewContextFromPath(path string, target *user.User) (*Context, error) {
 	}
 
 	log.Printf("%s is on %s filesystem %q (%s)", path,
-		ctx.Mount.Filesystem, ctx.Mount.Path, ctx.Mount.Device)
+		ctx.Mount.FilesystemType, ctx.Mount.Path, ctx.Mount.Device)
 	return ctx, nil
 }
 
@@ -95,7 +95,7 @@ func NewContextFromMountpoint(mountpoint string, target *user.User) (*Context, e
 		return nil, err
 	}
 
-	log.Printf("found %s filesystem %q (%s)", ctx.Mount.Filesystem,
+	log.Printf("found %s filesystem %q (%s)", ctx.Mount.FilesystemType,
 		ctx.Mount.Path, ctx.Mount.Device)
 	return ctx, nil
 }
@@ -137,9 +137,9 @@ func (ctx *Context) checkContext() error {
 func (ctx *Context) getService() string {
 	// For legacy configurations, we may need non-standard services
 	if ctx.Config.HasCompatibilityOption(LegacyConfig) {
-		switch ctx.Mount.Filesystem {
+		switch ctx.Mount.FilesystemType {
 		case "ext4", "f2fs":
-			return ctx.Mount.Filesystem + ":"
+			return ctx.Mount.FilesystemType + ":"
 		}
 	}
 	return unix.FS_KEY_DESC_PREFIX

--- a/cmd/fscrypt/status.go
+++ b/cmd/fscrypt/status.go
@@ -91,8 +91,8 @@ func writeGlobalStatus(w io.Writer) error {
 			continue
 		}
 
-		fmt.Fprintf(t, "%s\t%s\t%s\t%s\t%s\n", mount.Path, mount.Device, mount.Filesystem,
-			supportString, yesNoString(usingFscrypt))
+		fmt.Fprintf(t, "%s\t%s\t%s\t%s\t%s\n", mount.Path, mount.Device,
+			mount.FilesystemType, supportString, yesNoString(usingFscrypt))
 
 		if supportErr == nil {
 			supportCount++
@@ -139,8 +139,9 @@ func writeFilesystemStatus(w io.Writer, ctx *actions.Context) error {
 		return err
 	}
 
-	fmt.Fprintf(w, "%s filesystem %q has %s and %s\n\n", ctx.Mount.Filesystem, ctx.Mount.Path,
-		pluralize(len(options), "protector"), pluralize(len(policyDescriptors), "policy"))
+	fmt.Fprintf(w, "%s filesystem %q has %s and %s\n\n", ctx.Mount.FilesystemType,
+		ctx.Mount.Path, pluralize(len(options), "protector"),
+		pluralize(len(policyDescriptors), "policy"))
 
 	if len(options) > 0 {
 		writeOptions(w, options)

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -67,6 +67,9 @@ var (
 //	Path           - Absolute path where the directory is mounted
 //	FilesystemType - Type of the mounted filesystem, e.g. "ext4"
 //	Device         - Device for filesystem (empty string if we cannot find one)
+//	DeviceNumber   - Device number of the filesystem.  This is set even if
+//			 Device isn't, since all filesystems have a device
+//			 number assigned by the kernel, even pseudo-filesystems.
 //
 // In order to use a Mount to store fscrypt metadata, some directories must be
 // setup first. Specifically, the directories created look like:
@@ -92,6 +95,7 @@ type Mount struct {
 	Path           string
 	FilesystemType string
 	Device         string
+	DeviceNumber   DeviceNumber
 }
 
 // PathSorter allows mounts to be sorted by Path.

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -66,7 +66,6 @@ var (
 // Mount contains information for a specific mounted filesystem.
 //	Path           - Absolute path where the directory is mounted
 //	FilesystemType - Type of the mounted filesystem, e.g. "ext4"
-//	Options        - List of options used when mounting the filesystem
 //	Device         - Device for filesystem (empty string if we cannot find one)
 //
 // In order to use a Mount to store fscrypt metadata, some directories must be
@@ -92,7 +91,6 @@ var (
 type Mount struct {
 	Path           string
 	FilesystemType string
-	Options        []string
 	Device         string
 }
 
@@ -124,8 +122,7 @@ const (
 func (m *Mount) String() string {
 	return fmt.Sprintf(`%s
 	FilesystemType: %s
-	Options:        %v
-	Device:         %s`, m.Path, m.FilesystemType, m.Options, m.Device)
+	Device:         %s`, m.Path, m.FilesystemType, m.Device)
 }
 
 // BaseDir returns the path to the base fscrypt directory for this filesystem.

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -64,10 +64,10 @@ var (
 )
 
 // Mount contains information for a specific mounted filesystem.
-//	Path       - Absolute path where the directory is mounted
-//	Filesystem - Name of the mounted filesystem
-//	Options    - List of options used when mounting the filesystem
-//	Device     - Device for filesystem (empty string if we cannot find one)
+//	Path           - Absolute path where the directory is mounted
+//	FilesystemType - Type of the mounted filesystem, e.g. "ext4"
+//	Options        - List of options used when mounting the filesystem
+//	Device         - Device for filesystem (empty string if we cannot find one)
 //
 // In order to use a Mount to store fscrypt metadata, some directories must be
 // setup first. Specifically, the directories created look like:
@@ -90,10 +90,10 @@ var (
 // allows login protectors to be created when the root filesystem is read-only,
 // provided that "/.fscrypt" is a symlink pointing to a writable location.
 type Mount struct {
-	Path       string
-	Filesystem string
-	Options    []string
-	Device     string
+	Path           string
+	FilesystemType string
+	Options        []string
+	Device         string
 }
 
 // PathSorter allows mounts to be sorted by Path.
@@ -123,9 +123,9 @@ const (
 
 func (m *Mount) String() string {
 	return fmt.Sprintf(`%s
-	Filsystem: %s
-	Options:   %v
-	Device:    %s`, m.Path, m.Filesystem, m.Options, m.Device)
+	FilesystemType: %s
+	Options:        %v
+	Device:         %s`, m.Path, m.FilesystemType, m.Options, m.Device)
 }
 
 // BaseDir returns the path to the base fscrypt directory for this filesystem.

--- a/filesystem/mountpoint.go
+++ b/filesystem/mountpoint.go
@@ -134,12 +134,6 @@ func loadMountInfo() error {
 			continue
 		}
 
-		// Skip invalid mountpoints
-		var err error
-		if mnt.Path, err = canonicalizePath(mnt.Path); err != nil {
-			log.Printf("getting mnt_dir: %v", err)
-			continue
-		}
 		// We can only use mountpoints that are directories for fscrypt.
 		if !isDir(mnt.Path) {
 			log.Printf("ignoring mountpoint %q because it is not a directory", mnt.Path)
@@ -151,6 +145,7 @@ func loadMountInfo() error {
 		// filesystems are listed in mount order.
 		mountsByPath[mnt.Path] = mnt
 
+		var err error
 		mnt.Device, err = canonicalizePath(mnt.Device)
 		// Only use real valid devices (unlike cgroups, tmpfs, ...)
 		if err == nil && isDevice(mnt.Device) {

--- a/filesystem/mountpoint.go
+++ b/filesystem/mountpoint.go
@@ -87,9 +87,9 @@ func getMountInfo() error {
 
 		// Create the Mount structure by converting types.
 		mnt := Mount{
-			Path:       C.GoString(entry.mnt_dir),
-			Filesystem: C.GoString(entry.mnt_type),
-			Options:    strings.Split(C.GoString(entry.mnt_opts), ","),
+			Path:           C.GoString(entry.mnt_dir),
+			FilesystemType: C.GoString(entry.mnt_type),
+			Options:        strings.Split(C.GoString(entry.mnt_opts), ","),
 		}
 
 		// Skip invalid mountpoints

--- a/filesystem/mountpoint.go
+++ b/filesystem/mountpoint.go
@@ -89,7 +89,6 @@ func getMountInfo() error {
 		mnt := Mount{
 			Path:           C.GoString(entry.mnt_dir),
 			FilesystemType: C.GoString(entry.mnt_type),
-			Options:        strings.Split(C.GoString(entry.mnt_opts), ","),
 		}
 
 		// Skip invalid mountpoints

--- a/filesystem/mountpoint.go
+++ b/filesystem/mountpoint.go
@@ -57,10 +57,10 @@ var (
 	uuidDirectory = "/dev/disk/by-uuid"
 )
 
-// getMountInfo populates the Mount mappings by parsing the filesystem
+// loadMountInfo populates the Mount mappings by parsing the filesystem
 // description file using the getmntent functions. Returns ErrBadLoad if the
 // Mount mappings cannot be populated.
-func getMountInfo() error {
+func loadMountInfo() error {
 	if mountsInitialized {
 		return nil
 	}
@@ -122,7 +122,7 @@ func getMountInfo() error {
 func AllFilesystems() ([]*Mount, error) {
 	mountMutex.Lock()
 	defer mountMutex.Unlock()
-	if err := getMountInfo(); err != nil {
+	if err := loadMountInfo(); err != nil {
 		return nil, err
 	}
 
@@ -141,7 +141,7 @@ func UpdateMountInfo() error {
 	mountMutex.Lock()
 	defer mountMutex.Unlock()
 	mountsInitialized = false
-	return getMountInfo()
+	return loadMountInfo()
 }
 
 // FindMount returns the corresponding Mount object for some path in a
@@ -158,7 +158,7 @@ func FindMount(path string) (*Mount, error) {
 
 	mountMutex.Lock()
 	defer mountMutex.Unlock()
-	if err = getMountInfo(); err != nil {
+	if err = loadMountInfo(); err != nil {
 		return nil, err
 	}
 
@@ -189,7 +189,7 @@ func GetMount(mountpoint string) (*Mount, error) {
 
 	mountMutex.Lock()
 	defer mountMutex.Unlock()
-	if err = getMountInfo(); err != nil {
+	if err = loadMountInfo(); err != nil {
 		return nil, err
 	}
 
@@ -232,7 +232,7 @@ func getMountsFromLink(link string) ([]*Mount, error) {
 	// Lookup mountpoints for device in global store
 	mountMutex.Lock()
 	defer mountMutex.Unlock()
-	if err := getMountInfo(); err != nil {
+	if err := loadMountInfo(); err != nil {
 		return nil, err
 	}
 	mnts, ok := mountsByDevice[devicePath]

--- a/filesystem/mountpoint_test.go
+++ b/filesystem/mountpoint_test.go
@@ -17,15 +17,241 @@
  * the License.
  */
 
+// Note: these tests assume the existence of some well-known directories and
+// devices: /mnt, /home, /tmp, and /dev/loop0.  This is because the mountpoint
+// loading code only retains mountpoints on valid directories, and only retains
+// device names for valid device nodes.
+
 package filesystem
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestLoadMountInfo(t *testing.T) {
 	if err := UpdateMountInfo(); err != nil {
 		t.Error(err)
+	}
+}
+
+// Lock the mount maps so that concurrent tests don't interfere with each other.
+func beginLoadMountInfoTest() {
+	mountMutex.Lock()
+}
+
+func endLoadMountInfoTest() {
+	// Invalidate the fake mount information in case a test runs later which
+	// needs the real mount information.
+	mountsInitialized = false
+	mountMutex.Unlock()
+}
+
+func loadMountInfoFromString(str string) {
+	readMountInfo(strings.NewReader(str))
+}
+
+func mountForDevice(deviceNumberStr string) *Mount {
+	deviceNumber, _ := newDeviceNumberFromString(deviceNumberStr)
+	return mountsByDevice[deviceNumber]
+}
+
+// Test basic loading of a single mountpoint.
+func TestLoadMountInfoBasic(t *testing.T) {
+	var mountinfo = `
+15 0 259:3 / / rw,relatime shared:1 - ext4 /dev/root rw,data=ordered
+`
+	beginLoadMountInfoTest()
+	defer endLoadMountInfoTest()
+	loadMountInfoFromString(mountinfo)
+	if len(mountsByDevice) != 1 {
+		t.Error("Loaded wrong number of mounts")
+	}
+	mnt := mountForDevice("259:3")
+	if mnt == nil {
+		t.Fatal("Failed to load mount")
+	}
+	if mnt.Path != "/" {
+		t.Error("Wrong path")
+	}
+	if mnt.FilesystemType != "ext4" {
+		t.Error("Wrong filesystem type")
+	}
+	if mnt.DeviceNumber.String() != "259:3" {
+		t.Error("Wrong device number")
+	}
+	if mnt.BindMnt {
+		t.Error("Wrong bind mount flag")
+	}
+	if mnt.ReadOnly {
+		t.Error("Wrong readonly flag")
+	}
+}
+
+// Test that Mount.Device is set to the mountpoint's source device if
+// applicable, otherwise it is set to the empty string.
+func TestLoadSourceDevice(t *testing.T) {
+	var mountinfo = `
+15 0 7:0 / / rw shared:1 - foo /dev/loop0 rw,data=ordered
+31 15 0:27 / /tmp rw,nosuid,nodev shared:17 - tmpfs tmpfs rw
+`
+	beginLoadMountInfoTest()
+	defer endLoadMountInfoTest()
+	loadMountInfoFromString(mountinfo)
+	mnt := mountForDevice("7:0")
+	if mnt.Device != "/dev/loop0" {
+		t.Error("mnt.Device wasn't set to source device")
+	}
+	mnt = mountForDevice("0:27")
+	if mnt.Device != "" {
+		t.Error("mnt.Device wasn't set to empty string for an invalid device")
+	}
+}
+
+// Test that non-directory mounts are ignored.
+func TestNondirectoryMountsIgnored(t *testing.T) {
+	beginLoadMountInfoTest()
+	defer endLoadMountInfoTest()
+	file, err := ioutil.TempFile("", "fscrypt_regfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	file.Close()
+	defer os.Remove(file.Name())
+
+	mountinfo := fmt.Sprintf("15 0 259:3 /foo %s rw,relatime shared:1 - ext4 /dev/root rw", file.Name())
+	loadMountInfoFromString(mountinfo)
+	if len(mountsByDevice) != 0 {
+		t.Error("Non-directory mount wasn't ignored")
+	}
+}
+
+// Test that when multiple mounts are on one directory, the last is the one
+// which is kept.
+func TestNonLatestMountsIgnored(t *testing.T) {
+	mountinfo := `
+15 0 259:3 / / rw shared:1 - ext4 /dev/root rw
+15 0 259:3 / / rw shared:1 - f2fs /dev/root rw
+15 0 259:3 / / rw shared:1 - ubifs /dev/root rw
+`
+	beginLoadMountInfoTest()
+	defer endLoadMountInfoTest()
+	loadMountInfoFromString(mountinfo)
+	mnt := mountForDevice("259:3")
+	if mnt.FilesystemType != "ubifs" {
+		t.Error("Last mount didn't supersede previous ones")
+	}
+}
+
+// Test that escape sequences in the mountinfo file are unescaped correctly.
+func TestLoadMountWithSpecialCharacters(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "fscrypt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+	tempDir, err = filepath.Abs(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mountpoint := filepath.Join(tempDir, "/My Directory\t\n\\")
+	if err := os.Mkdir(mountpoint, 0700); err != nil {
+		t.Fatal(err)
+	}
+	mountinfo := fmt.Sprintf("15 0 259:3 / %s/My\\040Directory\\011\\012\\134 rw shared:1 - ext4 /dev/root rw", tempDir)
+
+	beginLoadMountInfoTest()
+	defer endLoadMountInfoTest()
+	loadMountInfoFromString(mountinfo)
+	mnt := mountForDevice("259:3")
+	if mnt.Path != mountpoint {
+		t.Fatal("Wrong mountpoint")
+	}
+}
+
+// Test parsing some invalid mountinfo lines.
+func TestLoadBadMountInfo(t *testing.T) {
+	mountinfos := []string{"a",
+		"a a a a a a a a a a a a a a a",
+		"a a a a a a a a a a a a - a a",
+		"15 0 BAD:3 / / rw,relatime shared:1 - ext4 /dev/root rw,data=ordered"}
+	beginLoadMountInfoTest()
+	defer endLoadMountInfoTest()
+	for _, mountinfo := range mountinfos {
+		loadMountInfoFromString(mountinfo)
+		if len(mountsByDevice) != 0 {
+			t.Error("Loaded mount from invalid mountinfo line")
+		}
+	}
+}
+
+// Test that the ReadOnly flag is set if the mount is readonly, even if the
+// filesystem is read-write.
+func TestLoadReadOnlyMount(t *testing.T) {
+	mountinfo := `
+222 15 259:3 / /mnt ro,relatime shared:1 - ext4 /dev/root rw,data=ordered
+`
+	beginLoadMountInfoTest()
+	defer endLoadMountInfoTest()
+	loadMountInfoFromString(mountinfo)
+	mnt := mountForDevice("259:3")
+	if !mnt.ReadOnly {
+		t.Error("Wrong readonly flag")
+	}
+}
+
+// Test that a read-write mount is preferred over a read-only mount.
+func TestReadWriteMountIsPreferredOverReadOnlyMount(t *testing.T) {
+	mountinfo := `
+222 15 259:3 / /home ro shared:1 - ext4 /dev/root rw
+222 15 259:3 / /mnt rw shared:1 - ext4 /dev/root rw
+222 15 259:3 / /tmp ro shared:1 - ext4 /dev/root rw
+`
+	beginLoadMountInfoTest()
+	defer endLoadMountInfoTest()
+	loadMountInfoFromString(mountinfo)
+	mnt := mountForDevice("259:3")
+	if mnt.Path != "/mnt" {
+		t.Error("Wrong mount was chosen")
+	}
+}
+
+// Test that a mount of the full filesystem is preferred over a bind mount.
+func TestFullMountIsPreferredOverBindMount(t *testing.T) {
+	mountinfo := `
+222 15 259:3 /subtree1 /home rw shared:1 - ext4 /dev/root rw
+222 15 259:3 / /mnt rw shared:1 - ext4 /dev/root rw
+222 15 259:3 /subtree2 /tmp rw shared:1 - ext4 /dev/root rw
+`
+	beginLoadMountInfoTest()
+	defer endLoadMountInfoTest()
+	loadMountInfoFromString(mountinfo)
+	mnt := mountForDevice("259:3")
+	if mnt.Path != "/mnt" {
+		t.Error("Wrong mount was chosen")
+	}
+}
+
+// Test that if a filesystem only has bind mounts, a nil mountsByDevice entry is
+// created.
+func TestLoadOnlyBindMounts(t *testing.T) {
+	mountinfo := `
+222 15 259:3 /foo /mnt ro,relatime shared:1 - ext4 /dev/root rw,data=ordered
+`
+	beginLoadMountInfoTest()
+	defer endLoadMountInfoTest()
+	loadMountInfoFromString(mountinfo)
+	deviceNumber, _ := newDeviceNumberFromString("259:3")
+	mnt, ok := mountsByDevice[deviceNumber]
+	if !ok {
+		t.Error("Entry should exist")
+	}
+	if mnt != nil {
+		t.Error("Entry should be nil")
 	}
 }
 

--- a/filesystem/path.go
+++ b/filesystem/path.go
@@ -73,12 +73,6 @@ func isDir(path string) bool {
 	return err == nil && info.IsDir()
 }
 
-// isDevice returns true if the path exists and is that of a device.
-func isDevice(path string) bool {
-	info, err := loggedStat(path)
-	return err == nil && info.Mode()&os.ModeDevice != 0
-}
-
 // isDirCheckPerm returns true if the path exists and is a directory. If the
 // specified permissions and sticky bit of mode do not match the path, an error
 // is logged.

--- a/filesystem/path.go
+++ b/filesystem/path.go
@@ -119,3 +119,13 @@ func getDeviceNumber(path string) (DeviceNumber, error) {
 	}
 	return DeviceNumber(stat.Rdev), nil
 }
+
+// getNumberOfContainingDevice returns the device number of the filesystem which
+// contains the given file.  If the file is a symlink, it is not dereferenced.
+func getNumberOfContainingDevice(path string) (DeviceNumber, error) {
+	var stat unix.Stat_t
+	if err := unix.Lstat(path, &stat); err != nil {
+		return 0, err
+	}
+	return DeviceNumber(stat.Dev), nil
+}

--- a/filesystem/path_test.go
+++ b/filesystem/path_test.go
@@ -1,0 +1,54 @@
+/*
+ * path_test.go - Tests for path utilities.
+ *
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package filesystem
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDeviceNumber(t *testing.T) {
+	num, err := getDeviceNumber("/NONEXISTENT")
+	if num != 0 || err == nil {
+		t.Error("Should have failed to get device number of nonexistent file")
+	}
+	// /dev/null is always device 1:3 on Linux.
+	num, err = getDeviceNumber("/dev/null")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if str := num.String(); str != "1:3" {
+		t.Errorf("Wrong device number string: %q", str)
+	}
+	if str := fmt.Sprintf("%v", num); str != "1:3" {
+		t.Errorf("Wrong device number string: %q", str)
+	}
+	var num2 DeviceNumber
+	num2, err = newDeviceNumberFromString("1:3")
+	if err != nil {
+		t.Error("Failed to parse device number")
+	}
+	if num2 != num {
+		t.Errorf("Wrong device number: %d", num2)
+	}
+	num2, err = newDeviceNumberFromString("foo")
+	if num2 != 0 || err == nil {
+		t.Error("Should have failed to parse invalid device number")
+	}
+}


### PR DESCRIPTION
Store fscrypt metadata in only one place per filesystem, so that bind mounts don't get their own metadata directories (which was ambiguous, as the same file may be accessible via multiple mounts).

Also correctly set the source device for root filesystems mounted via the kernel command line, and fix creating linked protectors to such filesystems.

See the commit messages for details.