### PR TITLE
Format variable declarations to maintain consistency

### DIFF
--- a/actions/callback.go
+++ b/actions/callback.go
@@ -85,7 +85,7 @@ func getWrappingKey(info ProtectorInfo, keyFn KeyFunc, retry bool) (*crypto.Key,
 // wrapping key until the correct key is returned by the callback or the
 // callback returns an error.
 func unwrapProtectorKey(info ProtectorInfo, keyFn KeyFunc) (*crypto.Key, error) {
-	retry := false
+	var retry bool
 	for {
 		wrappingKey, err := getWrappingKey(info, keyFn, retry)
 		if err != nil {

--- a/actions/policy.go
+++ b/actions/policy.go
@@ -47,7 +47,8 @@ var (
 // keyring. In order for this removal to have an effect, the filesystem should
 // also be unmounted.
 func PurgeAllPolicies(ctx *Context) error {
-	if err := ctx.checkContext(); err != nil {
+	var err error
+	if err = ctx.checkContext(); err != nil {
 		return err
 	}
 	policies, err := ctx.Mount.ListPolicies()
@@ -85,7 +86,8 @@ type Policy struct {
 // appropriate data on the filesystem. On error, no data is changed on the
 // filesystem.
 func CreatePolicy(ctx *Context, protector *Protector) (*Policy, error) {
-	if err := ctx.checkContext(); err != nil {
+	var err error
+	if err = ctx.checkContext(); err != nil {
 		return nil, err
 	}
 	// Randomly create the underlying policy key (and wipe if we fail)
@@ -133,7 +135,8 @@ func GetPolicy(ctx *Context, descriptor string) (*Policy, error) {
 // before using certain methods. An error is returned if the metadata is
 // inconsistent or the path is not encrypted.
 func GetPolicyFromPath(ctx *Context, path string) (*Policy, error) {
-	if err := ctx.checkContext(); err != nil {
+	var err error
+	if err = ctx.checkContext(); err != nil {
 		return nil, err
 	}
 

--- a/cmd/fscrypt/format.go
+++ b/cmd/fscrypt/format.go
@@ -130,7 +130,7 @@ var listRegex = regexp.MustCompile(`^\([\d]+\)$`)
 func wrapText(text string, padding int) string {
 	// We use a buffer to format the wrapped text so we get O(n) runtime
 	var buffer bytes.Buffer
-	spaceLeft := 0
+	var spaceLeft int
 	maxTextLen := lineLength - padding
 	delimiter := strings.Repeat(" ", padding)
 	for i, word := range strings.Fields(text) {

--- a/cmd/fscrypt/keys.go
+++ b/cmd/fscrypt/keys.go
@@ -59,7 +59,7 @@ type passphraseReader struct{}
 // should be called with the maximum buffer size for the passphrase.
 func (p passphraseReader) Read(buf []byte) (int, error) {
 	// We read one byte at a time to handle backspaces
-	position := 0
+	var position int
 	for {
 		if position == len(buf) {
 			return position, ErrMaxPassphrase

--- a/cmd/fscrypt/prompt.go
+++ b/cmd/fscrypt/prompt.go
@@ -249,7 +249,7 @@ func promptForProtector(options []*actions.ProtectorOption) (int, error) {
 	log.Printf("selecting from %s", pluralize(numOptions, "protector"))
 
 	// Get the number of load errors.
-	numLoadErrors := 0
+	var numLoadErrors int
 	for _, option := range options {
 		if option.LoadError != nil {
 			log.Printf("when loading option: %v", option.LoadError)

--- a/cmd/fscrypt/status.go
+++ b/cmd/fscrypt/status.go
@@ -72,8 +72,8 @@ func writeGlobalStatus(w io.Writer) error {
 		return err
 	}
 
-	supportCount := 0
-	useCount := 0
+	var supportCount int
+	var useCount int
 
 	t := makeTableWriter(w, "MOUNTPOINT\tDEVICE\tFILESYSTEM\tENCRYPTION\tFSCRYPT")
 	for _, mount := range mounts {

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -208,7 +208,7 @@ func NewKeyFromReader(reader io.Reader) (*Key, error) {
 		return nil, err
 	}
 
-	totalBytesRead := 0
+	var totalBytesRead int
 	for {
 		bytesRead, err := reader.Read(key.data[totalBytesRead:])
 		totalBytesRead += bytesRead

--- a/filesystem/mountpoint.go
+++ b/filesystem/mountpoint.go
@@ -183,7 +183,8 @@ func FindMount(path string) (*Mount, error) {
 // a filesystem has been updated since the last call to one of the mount
 // functions, run UpdateMountInfo to see changes.
 func GetMount(mountpoint string) (*Mount, error) {
-	mountpoint, err := canonicalizePath(mountpoint)
+	var err error
+	mountpoint, err = canonicalizePath(mountpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -130,7 +130,8 @@ func (h *Handle) GetItem(i Item) (unsafe.Pointer, error) {
 // StartAsPamUser sets the effective privileges to that of the PAM user, and
 // configures the PAM user's keyrings to be properly linked.
 func (h *Handle) StartAsPamUser() error {
-	if _, err := security.UserKeyringID(h.PamUser, true); err != nil {
+	var err error
+	if _, err = security.UserKeyringID(h.PamUser, true); err != nil {
 		log.Printf("Setting up keyrings in PAM: %v", err)
 	}
 	userPrivs, err := security.UserPrivileges(h.PamUser)

--- a/pam_fscrypt/pam_fscrypt.go
+++ b/pam_fscrypt/pam_fscrypt.go
@@ -61,13 +61,14 @@ var (
 // Authenticate copies the AUTHTOK (if necessary) into the PAM data so it can be
 // used in pam_sm_open_session.
 func Authenticate(handle *pam.Handle, _ map[string]bool) error {
-	if err := handle.StartAsPamUser(); err != nil {
+	var err error
+	if err = handle.StartAsPamUser(); err != nil {
 		return err
 	}
 	defer handle.StopAsPamUser()
 
 	// If this user doesn't have a login protector, no unlocking is needed.
-	if _, err := loginProtector(handle); err != nil {
+	if _, err = loginProtector(handle); err != nil {
 		log.Printf("no protector, no need for AUTHTOK: %s", err)
 		return nil
 	}


### PR DESCRIPTION
Prefer variable declarations adhering to go style, `var a int` over `a := 0`