### PR TITLE
Allow filesystem links to contain leading/trailing whitespace

### DIFF
--- a/filesystem/mountpoint.go
+++ b/filesystem/mountpoint.go
@@ -282,7 +282,7 @@ func GetMount(mountpoint string) (*Mount, error) {
 	return mnt, nil
 }
 
-// getMountsFromLink returns the Mount object which matches the provided link.
+// getMountFromLink returns the Mount object which matches the provided link.
 // This link is formatted as a tag (e.g. <token>=<value>) similar to how they
 // appear in "/etc/fstab". Currently, only "UUID" tokens are supported. An error
 // is returned if the link is invalid or we cannot load the required mount data.
@@ -290,6 +290,7 @@ func GetMount(mountpoint string) (*Mount, error) {
 // functions, run UpdateMountInfo to see the change.
 func getMountFromLink(link string) (*Mount, error) {
 	// Parse the link
+	link = strings.TrimSpace(link)
 	linkComponents := strings.Split(link, "=")
 	if len(linkComponents) != 2 {
 		return nil, errors.Wrapf(ErrFollowLink, "link %q format is invalid", link)

--- a/filesystem/mountpoint_test.go
+++ b/filesystem/mountpoint_test.go
@@ -255,6 +255,38 @@ func TestLoadOnlyBindMounts(t *testing.T) {
 	}
 }
 
+// Test making a filesystem link (i.e. "UUID=...") and following it, and test
+// that leading and trailing whitespace in the link is ignored.
+func TestGetMountFromLink(t *testing.T) {
+	mnt, err := getTestMount(t)
+	if err != nil {
+		t.Skip(err)
+	}
+	link, err := makeLink(mnt, uuidToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	linkedMnt, err := getMountFromLink(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linkedMnt != mnt {
+		t.Fatal("Link doesn't point to the same Mount")
+	}
+	if linkedMnt, err = getMountFromLink(link + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	if linkedMnt != mnt {
+		t.Fatal("Link doesn't point to the same Mount")
+	}
+	if linkedMnt, err = getMountFromLink("  " + link + "  \r\n"); err != nil {
+		t.Fatal(err)
+	}
+	if linkedMnt != mnt {
+		t.Fatal("Link doesn't point to the same Mount")
+	}
+}
+
 // Benchmarks how long it takes to update the mountpoint data
 func BenchmarkLoadFirst(b *testing.B) {
 	for n := 0; n < b.N; n++ {


### PR DESCRIPTION
To make manually editing linked protectors slightly more user-friendly,
automatically strip any leading or trailing whitespace.  E.g. treat
"UUID=3a6d9a76-47f0-4f13-81bf-3332fbe984fb\n" the same as
"UUID=3a6d9a76-47f0-4f13-81bf-3332fbe984fb".

Update https://github.com/google/fscrypt/issues/115