### PR TITLE
cmd/fscrypt: adjust message when listing protector sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Metadata directories created at "/mnt/disk/.fscrypt".
 >>>>> mkdir /mnt/disk/dir1
 >>>>> fscrypt encrypt /mnt/disk/dir1
 Should we create a new protector? [Y/n] y
-Your data can be protected with one of the following sources:
+The following protector sources are available:
 1 - Your login passphrase (pam_passphrase)
 2 - A custom passphrase (custom_passphrase)
 3 - A raw 256-bit key (raw_key)
@@ -364,7 +364,7 @@ passphrase.
 >>>>> mkdir /mnt/disk/dir2
 >>>>> fscrypt encrypt /mnt/disk/dir2
 Should we create a new protector? [Y/n] y
-Your data can be protected with one of the following sources:
+The following protector sources are available:
 1 - Your login passphrase (pam_passphrase)
 2 - A custom passphrase (custom_passphrase)
 3 - A raw 256-bit key (raw_key)
@@ -449,7 +449,7 @@ sure you are aware of
 # could also use `fscrypt encrypt --key=secret.key` to achieve the same thing.
 >>>>> fscrypt metadata create protector /mnt/disk
 Create new protector on "/mnt/disk" [Y/n] y
-Your data can be protected with one of the following sources:
+The following protector sources are available:
 1 - Your login passphrase (pam_passphrase)
 2 - A custom passphrase (custom_passphrase)
 3 - A raw 256-bit key (raw_key)

--- a/cmd/fscrypt/prompt.go
+++ b/cmd/fscrypt/prompt.go
@@ -185,7 +185,7 @@ func promptForSource(ctx *actions.Context) error {
 	}
 
 	// We print all the sources with their number, description, and name.
-	fmt.Println("Your data can be protected with one of the following sources:")
+	fmt.Println("The following protector sources are available:")
 	for idx := 1; idx < len(metadata.SourceType_value); idx++ {
 		source := metadata.SourceType(idx)
 		description := sourceDescriptions[source]


### PR DESCRIPTION
Saying "Your data can be protected with one of the following sources" is
ambiguous because it could be interpreted to mean that an encrypted
directory can only have one type of protector.  In fact, an encrypted
directory can have multiple protectors, and they can be of any type.

Update https://github.com/google/fscrypt/issues/164