### PR TITLE
travis: set GO111MODULE=on for 'go get'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
       name: Build and Unit Tests
       install: skip
       script:
-        - go get github.com/google/fscrypt/cmd/fscrypt
+        - GO111MODULE=on go get github.com/google/fscrypt/cmd/fscrypt
         - make
 
     - <<: *build


### PR DESCRIPTION
Ensure that the environmental variable GO111MODULE is set to "on" when
running 'go get'.  This fixes a CI failure with Go 1.11 and 1.12.