### PR TITLE
Rename some variables from 'target' to 'targetUser'

### DIFF
--- a/actions/context.go
+++ b/actions/context.go
@@ -66,10 +66,10 @@ type Context struct {
 
 // NewContextFromPath makes a context for the filesystem containing the
 // specified path and whose Config is loaded from the global config file. On
-// success, the Context contains a valid Config and Mount. The target defaults
-// to the current effective user if none is specified.
-func NewContextFromPath(path string, target *user.User) (*Context, error) {
-	ctx, err := newContextFromUser(target)
+// success, the Context contains a valid Config and Mount. The target user
+// defaults to the current effective user if none is specified.
+func NewContextFromPath(path string, targetUser *user.User) (*Context, error) {
+	ctx, err := newContextFromUser(targetUser)
 	if err != nil {
 		return nil, err
 	}
@@ -84,10 +84,10 @@ func NewContextFromPath(path string, target *user.User) (*Context, error) {
 
 // NewContextFromMountpoint makes a context for the filesystem at the specified
 // mountpoint and whose Config is loaded from the global config file. On
-// success, the Context contains a valid Config and Mount. The target defaults
-// to the current effective user if none is specified.
-func NewContextFromMountpoint(mountpoint string, target *user.User) (*Context, error) {
-	ctx, err := newContextFromUser(target)
+// success, the Context contains a valid Config and Mount. The target user
+// defaults to the current effective user if none is specified.
+func NewContextFromMountpoint(mountpoint string, targetUser *user.User) (*Context, error) {
+	ctx, err := newContextFromUser(targetUser)
 	if err != nil {
 		return nil, err
 	}
@@ -101,22 +101,22 @@ func NewContextFromMountpoint(mountpoint string, target *user.User) (*Context, e
 }
 
 // newContextFromUser makes a context with the corresponding target user, and
-// whose Config is loaded from the global config file. If the target is nil, the
-// effective user is used.
-func newContextFromUser(target *user.User) (*Context, error) {
+// whose Config is loaded from the global config file. If the target user is
+// nil, the effective user is used.
+func newContextFromUser(targetUser *user.User) (*Context, error) {
 	var err error
-	if target == nil {
-		if target, err = util.EffectiveUser(); err != nil {
+	if targetUser == nil {
+		if targetUser, err = util.EffectiveUser(); err != nil {
 			return nil, err
 		}
 	}
 
-	ctx := &Context{TargetUser: target}
+	ctx := &Context{TargetUser: targetUser}
 	if ctx.Config, err = getConfig(); err != nil {
 		return nil, err
 	}
 
-	log.Printf("creating context for %q", target.Username)
+	log.Printf("creating context for user %q", targetUser.Username)
 	return ctx, nil
 }
 

--- a/cmd/fscrypt/commands.go
+++ b/cmd/fscrypt/commands.go
@@ -138,11 +138,11 @@ func encryptAction(c *cli.Context) error {
 // keyring unless --skip-unlock is used. On failure, an error is returned, any
 // metadata creation is reverted, and the directory is unmodified.
 func encryptPath(path string) (err error) {
-	target, err := parseUserFlag(!skipUnlockFlag.Value)
+	targetUser, err := parseUserFlag(!skipUnlockFlag.Value)
 	if err != nil {
 		return
 	}
-	ctx, err := actions.NewContextFromPath(path, target)
+	ctx, err := actions.NewContextFromPath(path, targetUser)
 	if err != nil {
 		return
 	}
@@ -293,12 +293,12 @@ func unlockAction(c *cli.Context) error {
 		return expectedArgsErr(c, 1, false)
 	}
 
-	target, err := parseUserFlag(true)
+	targetUser, err := parseUserFlag(true)
 	if err != nil {
 		return newExitError(c, err)
 	}
 	path := c.Args().Get(0)
-	ctx, err := actions.NewContextFromPath(path, target)
+	ctx, err := actions.NewContextFromPath(path, targetUser)
 	if err != nil {
 		return newExitError(c, err)
 	}
@@ -377,12 +377,12 @@ func purgeAction(c *cli.Context) error {
 		}
 	}
 
-	target, err := parseUserFlag(true)
+	targetUser, err := parseUserFlag(true)
 	if err != nil {
 		return newExitError(c, err)
 	}
 	mountpoint := c.Args().Get(0)
-	ctx, err := actions.NewContextFromMountpoint(mountpoint, target)
+	ctx, err := actions.NewContextFromMountpoint(mountpoint, targetUser)
 	if err != nil {
 		return newExitError(c, err)
 	}
@@ -527,12 +527,12 @@ func createProtectorAction(c *cli.Context) error {
 		return expectedArgsErr(c, 1, false)
 	}
 
-	target, err := parseUserFlag(false)
+	targetUser, err := parseUserFlag(false)
 	if err != nil {
 		return newExitError(c, err)
 	}
 	mountpoint := c.Args().Get(0)
-	ctx, err := actions.NewContextFromMountpoint(mountpoint, target)
+	ctx, err := actions.NewContextFromMountpoint(mountpoint, targetUser)
 	if err != nil {
 		return newExitError(c, err)
 	}

--- a/cmd/fscrypt/flags.go
+++ b/cmd/fscrypt/flags.go
@@ -255,18 +255,18 @@ func matchMetadataFlag(flagValue string) (mountpoint, descriptor string, err err
 // parseMetadataFlag takes the value of either protectorFlag or policyFlag
 // formatted as MOUNTPOINT:DESCRIPTOR, and returns a context for the mountpoint
 // and a string for the descriptor.
-func parseMetadataFlag(flagValue string, target *user.User) (*actions.Context, string, error) {
+func parseMetadataFlag(flagValue string, targetUser *user.User) (*actions.Context, string, error) {
 	mountpoint, descriptor, err := matchMetadataFlag(flagValue)
 	if err != nil {
 		return nil, "", err
 	}
-	ctx, err := actions.NewContextFromMountpoint(mountpoint, target)
+	ctx, err := actions.NewContextFromMountpoint(mountpoint, targetUser)
 	return ctx, descriptor, err
 }
 
 // getProtectorFromFlag gets an existing locked protector from protectorFlag.
-func getProtectorFromFlag(flagValue string, target *user.User) (*actions.Protector, error) {
-	ctx, descriptor, err := parseMetadataFlag(flagValue, target)
+func getProtectorFromFlag(flagValue string, targetUser *user.User) (*actions.Protector, error) {
+	ctx, descriptor, err := parseMetadataFlag(flagValue, targetUser)
 	if err != nil {
 		return nil, err
 	}
@@ -274,8 +274,8 @@ func getProtectorFromFlag(flagValue string, target *user.User) (*actions.Protect
 }
 
 // getPolicyFromFlag gets an existing locked policy from policyFlag.
-func getPolicyFromFlag(flagValue string, target *user.User) (*actions.Policy, error) {
-	ctx, descriptor, err := parseMetadataFlag(flagValue, target)
+func getPolicyFromFlag(flagValue string, targetUser *user.User) (*actions.Policy, error) {
+	ctx, descriptor, err := parseMetadataFlag(flagValue, targetUser)
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -248,7 +248,7 @@ func NewFixedLengthKeyFromReader(reader io.Reader, length int) (*Key, error) {
 
 // InsertPolicyKey puts the provided policy key into the kernel keyring with the
 // provided description, and type logon. The key must be a policy key.
-func InsertPolicyKey(key *Key, description string, target *user.User) error {
+func InsertPolicyKey(key *Key, description string, targetUser *user.User) error {
 	if err := util.CheckValidLength(metadata.PolicyKeyLen, key.Len()); err != nil {
 		return errors.Wrap(err, "policy key")
 	}
@@ -267,7 +267,7 @@ func InsertPolicyKey(key *Key, description string, target *user.User) error {
 	fscryptKey.Size = metadata.PolicyKeyLen
 	copy(fscryptKey.Raw[:], key.data)
 
-	return security.InsertKey(payload.data, description, target)
+	return security.InsertKey(payload.data, description, targetUser)
 }
 
 var (

--- a/security/keyring.go
+++ b/security/keyring.go
@@ -47,8 +47,8 @@ var (
 // FindKey tries to locate a key in the kernel keyring with the provided
 // description. The key ID is returned if we can find the key. An error is
 // returned if the key does not exist.
-func FindKey(description string, target *user.User) (int, error) {
-	keyringID, err := UserKeyringID(target, false)
+func FindKey(description string, targetUser *user.User) (int, error) {
+	keyringID, err := UserKeyringID(targetUser, false)
 	if err != nil {
 		return 0, err
 	}
@@ -63,8 +63,8 @@ func FindKey(description string, target *user.User) (int, error) {
 
 // RemoveKey tries to remove a policy key from the kernel keyring with the
 // provided description. An error is returned if the key does not exist.
-func RemoveKey(description string, target *user.User) error {
-	keyID, err := FindKey(description, target)
+func RemoveKey(description string, targetUser *user.User) error {
+	keyID, err := FindKey(description, targetUser)
 	if err != nil {
 		return err
 	}
@@ -81,8 +81,8 @@ func RemoveKey(description string, target *user.User) error {
 
 // InsertKey puts the provided data into the kernel keyring with the provided
 // description.
-func InsertKey(data []byte, description string, target *user.User) error {
-	keyringID, err := UserKeyringID(target, true)
+func InsertKey(data []byte, description string, targetUser *user.User) error {
+	keyringID, err := UserKeyringID(targetUser, true)
 	if err != nil {
 		return err
 	}
@@ -106,8 +106,8 @@ var (
 // keyring and linking it into the root user keyring (permissions allowing). If
 // checkSession is true, an error is returned if a normal user requests their
 // user keyring, but it is not in the current session keyring.
-func UserKeyringID(target *user.User, checkSession bool) (int, error) {
-	uid := util.AtoiOrPanic(target.Uid)
+func UserKeyringID(targetUser *user.User, checkSession bool) (int, error) {
+	uid := util.AtoiOrPanic(targetUser.Uid)
 	targetKeyring, err := userKeyringIDLookup(uid)
 	if err != nil {
 		return 0, errors.Wrap(ErrAccessUserKeyring, err.Error())


### PR DESCRIPTION
Refer to the target User as 'targetUser' rather than simply 'target'.
This will help avoid confusion when we add support for the filesystem
keyring, since then the Mount will also be a "target".