### PR TITLE
filesystem: remove canonicalizePath()

### DIFF
--- a/filesystem/mountpoint.go
+++ b/filesystem/mountpoint.go
@@ -319,9 +319,8 @@ func getMountFromLink(link string) (*Mount, error) {
 	}
 	mnt, ok := mountsByDevice[deviceNumber]
 	if !ok {
-		devicePath, _ := canonicalizePath(searchPath)
 		return nil, errors.Wrapf(ErrFollowLink, "no mounts for device %q (%v)",
-			devicePath, deviceNumber)
+			getDeviceName(deviceNumber), deviceNumber)
 	}
 	if mnt == nil {
 		return nil, filesystemRootDirNotVisibleError(deviceNumber)

--- a/filesystem/path.go
+++ b/filesystem/path.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 
 	"golang.org/x/sys/unix"
 
@@ -40,22 +39,6 @@ func OpenFileOverridingUmask(name string, flag int, perm os.FileMode) (*os.File,
 
 // We only check the unix permissions and the sticky bit
 const permMask = os.ModeSticky | os.ModePerm
-
-// canonicalizePath turns path into an absolute path without symlinks.
-func canonicalizePath(path string) (string, error) {
-	path, err := filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-	path, err = filepath.EvalSymlinks(path)
-
-	// Get a better error if we have an invalid path
-	if pathErr, ok := err.(*os.PathError); ok {
-		err = errors.Wrap(pathErr.Err, pathErr.Path)
-	}
-
-	return path, err
-}
 
 // loggedStat runs os.Stat, but it logs the error if stat returns any error
 // other than nil or IsNotExist.


### PR DESCRIPTION
canonicalizePath() is now only used by an error path in
getMountFromLink(), which we can make use getDeviceName() instead.