### PR TITLE
cmd/fscrypt/setup: don't prompt to create /etc/fscrypt.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,6 @@ MOUNTPOINT  DEVICE     FILESYSTEM  ENCRYPTION   FSCRYPT
 
 # Create the global configuration file. Nothing else necessarily needs root.
 >>>>> sudo fscrypt setup
-Create "/etc/fscrypt.conf"? [Y/n] y
 Customizing passphrase hashing difficulty for this system...
 Created global config file at "/etc/fscrypt.conf".
 Metadata directories created at "/.fscrypt".

--- a/cmd/fscrypt/setup.go
+++ b/cmd/fscrypt/setup.go
@@ -35,7 +35,7 @@ func createGlobalConfig(w io.Writer, path string) error {
 		return ErrMustBeRoot
 	}
 
-	// Ask to create or replace the config file
+	// If the config file already exists, ask to replace it
 	_, err := os.Stat(path)
 	switch {
 	case err == nil:
@@ -44,7 +44,7 @@ func createGlobalConfig(w io.Writer, path string) error {
 			err = os.Remove(path)
 		}
 	case os.IsNotExist(err):
-		err = askConfirmation(fmt.Sprintf("Create %q?", path), true, "")
+		err = nil
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
When 'fscrypt setup' sees that /etc/fscrypt.conf doesn't exist, don't
ask for confirmation before creating it.  Just do it.  This is the
normal use, and there's not a good reason to ask the user to confirm it.