### PR TITLE
cmd/fscrypt/errors: explicitly mark error messages as errors

### DIFF
--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -169,12 +169,12 @@ func getErrorSuggestions(err error) string {
 }
 
 // newExitError creates a new error for a given context and normal error. The
-// returned error prepends the name of the relevant command and will make
-// fscrypt return a non-zero exit value.
+// returned error prepends an error tag and the name of the relevant command,
+// and it will make fscrypt return a non-zero exit value.
 func newExitError(c *cli.Context, err error) error {
-	// Prepend the full name and append suggestions (if any)
-	fullNamePrefix := getFullName(c) + ": "
-	message := fullNamePrefix + wrapText(err.Error(), utf8.RuneCountInString(fullNamePrefix))
+	// Prepend the error tag and full name, and append suggestions (if any)
+	prefix := "[ERROR] " + getFullName(c) + ": "
+	message := prefix + wrapText(err.Error(), utf8.RuneCountInString(prefix))
 
 	if suggestion := getErrorSuggestions(err); suggestion != "" {
 		message += "\n\n" + wrapText(suggestion, 0)


### PR DESCRIPTION
When an fscrypt command fails and prints an error message, in some cases
it isn't clear that the message is actually an error, e.g.:

    fscrypt encrypt: login protectors do not need a name

Make it clear by always prefixing the message with "[ERROR] ", e.g.

    [ERROR] fscrypt encrypt: login protectors do not need a name

Update https://github.com/google/fscrypt/issues/186