### PR TITLE
Clean up policies and protectors on error

### DIFF
--- a/actions/policy.go
+++ b/actions/policy.go
@@ -315,7 +315,7 @@ func (policy *Policy) AddProtector(protector *Protector) error {
 	// to it on the policy's filesystem.
 	if policy.Context.Mount != protector.Context.Mount {
 		log.Printf("policy on %s\n protector on %s\n", policy.Context.Mount, protector.Context.Mount)
-		err := policy.Context.Mount.AddLinkedProtector(
+		_, err := policy.Context.Mount.AddLinkedProtector(
 			protector.Descriptor(), protector.Context.Mount)
 		if err != nil {
 			return err

--- a/actions/policy.go
+++ b/actions/policy.go
@@ -79,10 +79,11 @@ func PurgeAllPolicies(ctx *Context) error {
 // allow encrypted files to be accessed). As with the key struct, a Policy
 // should be wiped after use.
 type Policy struct {
-	Context *Context
-	data    *metadata.PolicyData
-	key     *crypto.Key
-	created bool
+	Context             *Context
+	data                *metadata.PolicyData
+	key                 *crypto.Key
+	created             bool
+	newLinkedProtectors []string
 }
 
 // CreatePolicy creates a Policy protected by given Protector and stores the
@@ -208,9 +209,13 @@ func (policy *Policy) Version() int64 {
 	return policy.data.Options.PolicyVersion
 }
 
-// Destroy removes a policy from the filesystem. The internal key should still
-// be wiped with Lock().
+// Destroy removes a policy from the filesystem. It also removes any new
+// protector links that were created for the policy. This does *not* wipe the
+// policy's internal key from memory; use Lock() to do that.
 func (policy *Policy) Destroy() error {
+	for _, protectorDescriptor := range policy.newLinkedProtectors {
+		policy.Context.Mount.RemoveProtector(protectorDescriptor)
+	}
 	return policy.Context.Mount.RemovePolicy(policy.Descriptor())
 }
 
@@ -315,10 +320,14 @@ func (policy *Policy) AddProtector(protector *Protector) error {
 	// to it on the policy's filesystem.
 	if policy.Context.Mount != protector.Context.Mount {
 		log.Printf("policy on %s\n protector on %s\n", policy.Context.Mount, protector.Context.Mount)
-		_, err := policy.Context.Mount.AddLinkedProtector(
+		isNewLink, err := policy.Context.Mount.AddLinkedProtector(
 			protector.Descriptor(), protector.Context.Mount)
 		if err != nil {
 			return err
+		}
+		if isNewLink {
+			policy.newLinkedProtectors = append(policy.newLinkedProtectors,
+				protector.Descriptor())
 		}
 	} else {
 		log.Printf("policy and protector both on %q", policy.Context.Mount)

--- a/actions/recovery.go
+++ b/actions/recovery.go
@@ -78,6 +78,7 @@ func AddRecoveryPassphrase(policy *Policy, dirname string) (*crypto.Key, *Protec
 		seq++
 	}
 	if err := policy.AddProtector(recoveryProtector); err != nil {
+		recoveryProtector.Revert()
 		return nil, nil, err
 	}
 	return passphrase, recoveryProtector, nil

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -351,8 +351,18 @@ func TestLinkedProtector(t *testing.T) {
 	}
 
 	// Add the link to the second filesystem
-	if err = fakeMnt.AddLinkedProtector(protector.ProtectorDescriptor, realMnt); err != nil {
+	var isNewLink bool
+	if isNewLink, err = fakeMnt.AddLinkedProtector(protector.ProtectorDescriptor, realMnt); err != nil {
 		t.Fatal(err)
+	}
+	if !isNewLink {
+		t.Fatal("Link was not new")
+	}
+	if isNewLink, err = fakeMnt.AddLinkedProtector(protector.ProtectorDescriptor, realMnt); err != nil {
+		t.Fatal(err)
+	}
+	if isNewLink {
+		t.Fatal("Link was new")
 	}
 
 	// Get the protector though the second system


### PR DESCRIPTION
Ensure that new policies and protectors always get deleted if `fscrypt encrypt` fails partway through.

Update https://github.com/google/fscrypt/issues/186