### PR TITLE
cmd/fscrypt/commands: allow disabling recovery passphrase

### DIFF
--- a/cmd/fscrypt/flags.go
+++ b/cmd/fscrypt/flags.go
@@ -116,7 +116,7 @@ var (
 	allFlags = []prettyFlag{helpFlag, versionFlag, verboseFlag, quietFlag,
 		forceFlag, legacyFlag, skipUnlockFlag, timeTargetFlag,
 		sourceFlag, nameFlag, keyFileFlag, protectorFlag,
-		unlockWithFlag, policyFlag, allUsersFlag}
+		unlockWithFlag, policyFlag, allUsersFlag, noRecoveryFlag}
 	// universalFlags contains flags that should be on every command
 	universalFlags = []cli.Flag{verboseFlag, quietFlag, helpFlag}
 )
@@ -177,6 +177,10 @@ var (
 			necessary if the directory was unlocked by a user
 			different from the one you're locking it as. This flag
 			is only implemented for v2 encryption policies.`,
+	}
+	noRecoveryFlag = &boolFlag{
+		Name:  "no-recovery",
+		Usage: `Don't ask to generate a recovery passphrase.`,
 	}
 )
 


### PR DESCRIPTION
While it's important to generate a recovery passphrase in the linked protector case to avoid data loss if the system is reinstalled, some people really don't want it (even though it can be safely ignored as it almost certainly has far more entropy than the login passphrase).
    
As a compromise, prompt for y/n before generating it, with default y.  Also, to allow disabling the recovery passphrase during noninteractive use, add a --no-recovery command-line option.
    
Update https://github.com/google/fscrypt/issues/186
