### PR TITLE
Makefile: clean up installation commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,12 @@ PAM_NAME := pam_$(NAME)
 
 ###### Makefile Command Line Flags ######
 #
-# BIN: The locaton where binaries will be built.    Default: ./bin
-# INSTALL: The tool used to install binaries.       Default: sudo install
-# DESTDIR: Prefix for all install paths             Default: ""
-# BINDIR: The location for the fscrypt binary.      Default: /usr/local/bin
-# PAM_MODULE_DIR: The location for pam_fscrypt.so.  Default: /lib/security
+# BIN: The location where binaries will be built.     Default: bin
+# DESTDIR: Installation destination directory.        Default: ""
+# PREFIX: Installation path prefix.                   Default: /usr/local
+# BINDIR: Where to install the fscrypt binary.        Default: $(PREFIX)/bin
+# PAM_MODULE_DIR: Where to install pam_fscrypt.so.    Default: $(PREFIX)/lib/security
+# PAM_CONFIG_DIR: Where to install Ubuntu PAM config. Default: $(PREFIX)/share/pam-configs
 #
 # MOUNT: The filesystem where our tests are run.    Default: /mnt/fscrypt_mount
 #   Ex: make test-setup MOUNT=/foo/bar
@@ -152,8 +153,8 @@ PREFIX := /usr/local
 BINDIR := $(PREFIX)/bin
 
 install-bin: $(BIN)/$(NAME)
-	install -d $(DESTDIR)/$(BINDIR)
-	install $< $(DESTDIR)/$(BINDIR)
+	install -d $(DESTDIR)$(BINDIR)
+	install $< $(DESTDIR)$(BINDIR)
 
 PAM_MODULE_DIR := $(PREFIX)/lib/security
 PAM_INSTALL_PATH := $(PAM_MODULE_DIR)/$(PAM_NAME).so
@@ -161,15 +162,17 @@ PAM_CONFIG := $(BIN)/config
 PAM_CONFIG_DIR := $(PREFIX)/share/pam-configs
 
 install-pam: $(PAM_MODULE)
-	install -d $(DESTDIR)/$(PAM_MODULE_DIR)
-	install $(PAM_MODULE) $(DESTDIR)/$(PAM_MODULE_DIR)
+	install -d $(DESTDIR)$(PAM_MODULE_DIR)
+	install $(PAM_MODULE) $(DESTDIR)$(PAM_MODULE_DIR)
 
 	m4 --define=PAM_INSTALL_PATH=$(PAM_INSTALL_PATH) < $(PAM_NAME)/config > $(PAM_CONFIG)
-	install -d $(DESTDIR)/$(PAM_CONFIG_DIR)
-	install $(PAM_CONFIG) $(DESTDIR)/$(PAM_CONFIG_DIR)/$(NAME)
+	install -d $(DESTDIR)$(PAM_CONFIG_DIR)
+	install $(PAM_CONFIG) $(DESTDIR)$(PAM_CONFIG_DIR)/$(NAME)
 
 uninstall:
-	rm -f $(DESTDIR)/$(BINDIR)/$(NAME) $(DESTDIR)/$(PAM_INSTALL_PATH) $(DESTDIR)/$(PAM_CONFIG_DIR)/$(NAME)
+	rm -f $(DESTDIR)$(BINDIR)/$(NAME) \
+	      $(DESTDIR)$(PAM_INSTALL_PATH) \
+	      $(DESTDIR)$(PAM_CONFIG_DIR)/$(NAME)
 
 #### Tool Building Commands ####
 TOOLS := $(addprefix $(BIN)/,protoc golint protoc-gen-go goimports staticcheck gocovmerge misspell)


### PR DESCRIPTION
Improve the documentation for the installation-related Makefile
variables, and update the commands to remove the forward slash after
$(DESTDIR) in order to remove a duplicate forward slash and match the
recommended usage.