### PR TITLE
cmd: Simplify "fscrypt --version" output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,8 @@ GO_LINK_FLAGS := -s -w
 # Flag to embed the version (pulled from tags) into the binary.
 TAG_VERSION := $(shell git describe --tags)
 VERSION_FLAG := -X "main.version=$(if $(TAG_VERSION),$(TAG_VERSION),$(VERSION))"
-# Flag to embed the date and time of the build into the binary.
-DATE_FLAG := -X "main.buildTime=$(shell date)"
 
-override GO_LINK_FLAGS += $(VERSION_FLAG) $(DATE_FLAG) -extldflags "$(LDFLAGS)"
+override GO_LINK_FLAGS += $(VERSION_FLAG) -extldflags "$(LDFLAGS)"
 override GO_FLAGS += --ldflags '$(GO_LINK_FLAGS)'
 # Always use Go modules
 export GO111MODULE = on

--- a/cmd/fscrypt/flags.go
+++ b/cmd/fscrypt/flags.go
@@ -129,7 +129,7 @@ var (
 	}
 	versionFlag = &boolFlag{
 		Name:  "version",
-		Usage: `Prints version and license information.`,
+		Usage: `Prints version information.`,
 	}
 	verboseFlag = &boolFlag{
 		Name:  "verbose",

--- a/cmd/fscrypt/fscrypt.go
+++ b/cmd/fscrypt/fscrypt.go
@@ -29,22 +29,12 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"time"
 
 	"github.com/urfave/cli"
 )
 
-var (
-	// Current version of the program (set by Makefile)
-	version string
-	// Formatted build time (set by Makefile)
-	buildTime string
-	// Authors to display in the info command
-	Authors = []cli.Author{{
-		Name:  "Joe Richey",
-		Email: "joerichey@google.com",
-	}}
-)
+// Current version of the program (set by Makefile)
+var version string
 
 func main() {
 	cli.AppHelpTemplate = appHelpTemplate
@@ -54,20 +44,14 @@ func main() {
 	// Create our command line application
 	app := cli.NewApp()
 	app.Usage = shortUsage
-	app.Authors = Authors
-	app.Copyright = apache2GoogleCopyright
 
-	// Grab the version and compilation time passed in from the Makefile.
+	// Grab the version passed in from the Makefile.
 	app.Version = version
-	app.Compiled, _ = time.Parse(time.UnixDate, buildTime)
 	app.OnUsageError = onUsageError
 
 	// Setup global flags
 	cli.HelpFlag = helpFlag
 	cli.VersionFlag = versionFlag
-	cli.VersionPrinter = func(c *cli.Context) {
-		cli.HelpPrinter(c.App.Writer, versionInfoTemplate, c.App)
-	}
 	app.Flags = universalFlags
 
 	// We hide the help subcommand so that "fscrypt <command> --help" works

--- a/cmd/fscrypt/strings.go
+++ b/cmd/fscrypt/strings.go
@@ -25,24 +25,7 @@ import (
 	"strings"
 )
 
-// Global application strings
-const (
-	shortUsage = "A tool for managing Linux filesystem encryption"
-
-	apache2GoogleCopyright = `Copyright 2017 Google, Inc.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.`
-)
+const shortUsage = "A tool for managing Linux filesystem encryption"
 
 // Argument usage strings
 const (
@@ -103,23 +86,6 @@ Options:
 {{range .VisibleFlags}}{{.}}
 
 {{end}}{{end}}`
-
-	// Additional info, used with "fscrypt version"
-	versionInfoTemplate = `{{.HelpName}} - {{.Usage}}
-
-{{if .Version}}Version:
-` + indent + `{{.Version}}
-
-{{end}}{{if not .Compiled.IsZero}}Compiled:
-` + indent + `{{.Compiled}}
-
-{{end}}{{if len .Authors}}Author{{with $length := len .Authors}}{{if ne 1 $length}}s{{end}}{{end}}:{{range .Authors}}
-` + indent + `{{.}}{{end}}
-
-{{end}}{{if .Copyright}}Copyright:
-` + indent + `{{.Copyright}}
-
-{{end}}`
 )
 
 // Add words to this map to have pluralize support them.


### PR DESCRIPTION
There's no need to include the build time, author, and copyright info
in the output of "fscrypt --version". This information is:

  - Overly complex (the current string is hard to parse)
  - Inaccurate (there are other authors than just me)
  - Unnecessary (the Apache 2 license is for Source Code)
  - Makes reproducible builds impossible (fixes #206)

The default version string is just fine.

Signed-off-by: Joe Richey <joerichey@google.com>