### PR TITLE
Makefile: Use trimpath if avalible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,10 @@ override GO_LINK_FLAGS += $(VERSION_FLAG) -extldflags "$(LDFLAGS)"
 override GO_FLAGS += --ldflags '$(GO_LINK_FLAGS)'
 # Always use Go modules
 export GO111MODULE = on
+# Use -trimpath if available
+ifneq "" "$(shell go help build | grep trimpath)"
+override GO_FLAGS += -trimpath
+endif
 
 ###### Find All Files and Directories ######
 FILES := $(shell find . -path '*/.git*' -prune -o -type f -printf "%P\n")


### PR DESCRIPTION
Passing -trimpath makes the build entirely reproducible. See #206 

Running `make` on two different computers (both Arch Linux, `go1.14.1`) gives a `sha256sum` of:
```
e6874f16445f7130cb1f7db63fb50850804f49d9b35af25e0a0f89b091f09ab7  ./bin/fscrypt
```

Signed-off-by: Joe Richey <joerichey@google.com>