### PR TITLE
Allow fscrypt to work in containers

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -70,8 +70,9 @@ var (
 //	DeviceNumber   - Device number of the filesystem.  This is set even if
 //			 Device isn't, since all filesystems have a device
 //			 number assigned by the kernel, even pseudo-filesystems.
-//	BindMnt        - True if this mount is not for the full filesystem but
-//			 rather is only for a subtree.
+//	Subtree        - The mounted subtree of the filesystem.  This is usually
+//			 "/", meaning that the entire filesystem is mounted, but
+//			 it can differ for bind mounts.
 //	ReadOnly       - True if this is a read-only mount
 //
 // In order to use a Mount to store fscrypt metadata, some directories must be
@@ -99,7 +100,7 @@ type Mount struct {
 	FilesystemType string
 	Device         string
 	DeviceNumber   DeviceNumber
-	BindMnt        bool
+	Subtree        string
 	ReadOnly       bool
 }
 


### PR DESCRIPTION
Update the /proc/self/mountinfo parsing code to allow selecting a Mount
with Subtree != "/", i.e. a Mount not of the full filesystem.  This is
needed to allow fscrypt to work in containers, where the root of the
filesystem may not be mounted.

See findMainMount() for details about the algorithm used.

Resolves https://github.com/google/fscrypt/issues/211