### PR TITLE
Try to detect incomplete locking of v1-encrypted directory

### DIFF
--- a/actions/policy.go
+++ b/actions/policy.go
@@ -417,12 +417,6 @@ func (policy *Policy) IsProvisionedByTargetUser() bool {
 	return policy.GetProvisioningStatus() == keyring.KeyPresent
 }
 
-// IsFullyDeprovisioned returns true if the policy has been fully deprovisioned,
-// including by all users and with all files protected by it having been closed.
-func (policy *Policy) IsFullyDeprovisioned() bool {
-	return policy.GetProvisioningStatus() == keyring.KeyAbsent
-}
-
 // Provision inserts the Policy key into the kernel keyring. This allows reading
 // and writing of files encrypted with this directory. Requires unlocked Policy.
 func (policy *Policy) Provision() error {
@@ -435,14 +429,15 @@ func (policy *Policy) Provision() error {
 
 // Deprovision removes the Policy key from the kernel keyring. This prevents
 // reading and writing to the directory --- unless the target keyring is a user
-// keyring, in which case caches must be dropped too.
+// keyring, in which case caches must be dropped too. If the Policy key was
+// already removed, returns keyring.ErrKeyNotPresent.
 func (policy *Policy) Deprovision(allUsers bool) error {
 	return keyring.RemoveEncryptionKey(policy.Descriptor(),
 		policy.Context.getKeyringOptions(), allUsers)
 }
 
 // NeedsUserKeyring returns true if Provision and Deprovision for this policy
-// will use a user keyring, not a filesystem keyring.
+// will use a user keyring (deprecated), not a filesystem keyring.
 func (policy *Policy) NeedsUserKeyring() bool {
 	return policy.Version() == 1 && !policy.Context.Config.GetUseFsKeyringForV1Policies()
 }

--- a/cli-tests/t_v1_policy.out
+++ b/cli-tests/t_v1_policy.out
@@ -96,3 +96,42 @@ Protected with 1 protector:
 PROTECTOR         LINKED  DESCRIPTION
 desc2  No      custom protector "prot"
 cat: MNT/dir/file: No such file or directory
+
+# Testing incompletely locking v1-encrypted directory
+Enter custom passphrase for protector "prot": "MNT/dir" is now unlocked and ready for use.
+Encrypted data removed from filesystem cache.
+[ERROR] fscrypt lock: some files using the key are still open
+
+Directory was incompletely locked because some files are still open. These files
+remain accessible. Try killing any processes using files in the directory, then
+re-running 'fscrypt lock'.
+"MNT/dir" is encrypted with fscrypt.
+
+Policy:   desc1
+Options:  padding:32 contents:AES_256_XTS filenames:AES_256_CTS policy_version:1 
+Unlocked: Partially (incompletely locked)
+
+Protected with 1 protector:
+PROTECTOR         LINKED  DESCRIPTION
+desc2  No      custom protector "prot"
+ext4 filesystem "MNT" has 1 protector and 1 policy
+
+PROTECTOR         LINKED  DESCRIPTION
+desc2  No      custom protector "prot"
+
+POLICY            UNLOCKED  PROTECTORS
+desc1  No        desc2
+
+# Finishing locking v1-encrypted directory
+Encrypted data removed from filesystem cache.
+"MNT/dir" is now locked.
+"MNT/dir" is encrypted with fscrypt.
+
+Policy:   desc1
+Options:  padding:32 contents:AES_256_XTS filenames:AES_256_CTS policy_version:1 
+Unlocked: No
+
+Protected with 1 protector:
+PROTECTOR         LINKED  DESCRIPTION
+desc2  No      custom protector "prot"
+cat: MNT/dir/file: No such file or directory

--- a/cli-tests/t_v1_policy.sh
+++ b/cli-tests/t_v1_policy.sh
@@ -54,3 +54,18 @@ _print_header "Lock v1-encrypted directory"
 fscrypt lock "$dir" --user="$TEST_USER"
 _user_do "fscrypt status '$dir'"
 _expect_failure "cat '$dir/file'"
+
+# 'fscrypt lock' and 'fscrypt status' implement a heuristic that should detect
+# the "files busy" case with v1.
+_print_header "Testing incompletely locking v1-encrypted directory"
+_user_do "echo hunter2 | fscrypt unlock '$dir'"
+exec 3<"$dir/file"
+_expect_failure "fscrypt lock '$dir' --user='$TEST_USER'"
+_user_do "fscrypt status '$dir'"
+# ... except in this case, because we can't detect it without a directory path.
+_user_do "fscrypt status '$MNT'"
+exec 3<&-
+_print_header "Finishing locking v1-encrypted directory"
+fscrypt lock "$dir" --user="$TEST_USER"
+_user_do "fscrypt status '$dir'"
+_expect_failure "cat '$dir/file'"

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -173,7 +173,7 @@ func GetEncryptionKeyStatus(descriptor string, options *Options) (KeyStatus, err
 	if useFsKeyring {
 		return fsGetEncryptionKeyStatus(descriptor, options.Mount, options.User)
 	}
-	_, err = userFindKey(buildKeyDescription(options, descriptor), options.User)
+	_, _, err = userFindKey(buildKeyDescription(options, descriptor), options.User)
 	if err != nil {
 		return KeyAbsent, nil
 	}


### PR DESCRIPTION
'fscrypt lock' on a v1-encrypted directory doesn't warn about in-use
files, as the kernel doesn't provide a way to easily detect it.

Instead, implement a heuristic where we check whether a subdirectory can
be created.  If yes, then the directory must not be fully locked.

Make both 'fscrypt lock' and 'fscrypt status' use this heuristic.

Resolves https://github.com/google/fscrypt/issues/215