### PR TITLE
Improve error messages and suggestions

### DIFF
--- a/actions/context.go
+++ b/actions/context.go
@@ -40,14 +40,8 @@ import (
 	"github.com/google/fscrypt/util"
 )
 
-// Errors relating to Config files or Config structures.
-var (
-	ErrNoConfigFile     = errors.New("global config file does not exist")
-	ErrBadConfigFile    = errors.New("global config file has invalid data")
-	ErrConfigFileExists = errors.New("global config file already exists")
-	ErrBadConfig        = errors.New("invalid Config structure provided")
-	ErrLocked           = errors.New("key needs to be unlocked first")
-)
+// ErrLocked indicates that the key hasn't been unwrapped yet.
+var ErrLocked = errors.New("key needs to be unlocked first")
 
 // Context contains the necessary global state to perform most of fscrypt's
 // actions.
@@ -126,7 +120,7 @@ func newContextFromUser(targetUser *user.User) (*Context, error) {
 // which is being used with fscrypt.
 func (ctx *Context) checkContext() error {
 	if err := ctx.Config.CheckValidity(); err != nil {
-		return errors.Wrap(ErrBadConfig, err.Error())
+		return &ErrBadConfig{ctx.Config, err}
 	}
 	return ctx.Mount.CheckSetup()
 }

--- a/actions/policy.go
+++ b/actions/policy.go
@@ -34,16 +34,109 @@ import (
 	"github.com/google/fscrypt/util"
 )
 
-// Errors relating to Policies
-var (
-	ErrMissingPolicyMetadata  = util.SystemError("missing policy metadata for encrypted directory")
-	ErrPolicyMetadataMismatch = util.SystemError("inconsistent metadata between filesystem and directory")
-	ErrDifferentFilesystem    = errors.New("policies may only protect files on the same filesystem")
-	ErrOnlyProtector          = errors.New("cannot remove the only protector for a policy")
-	ErrAlreadyProtected       = errors.New("policy already protected by protector")
-	ErrNotProtected           = errors.New("policy not protected by protector")
-	ErrAccessDeniedPossiblyV2 = errors.New("permission denied")
-)
+// ErrAccessDeniedPossiblyV2 indicates that a directory's encryption policy
+// couldn't be retrieved due to "permission denied", but it looks like it's due
+// to the directory using a v2 policy but the kernel not supporting it.
+type ErrAccessDeniedPossiblyV2 struct {
+	DirPath string
+}
+
+func (err *ErrAccessDeniedPossiblyV2) Error() string {
+	return fmt.Sprintf(`
+	failed to get encryption policy of %s: permission denied
+
+	This may be caused by the directory using a v2 encryption policy and the
+	current kernel not supporting it. If indeed the case, then this
+	directory can only be used on kernel v5.4 and later. You can create
+	directories accessible on older kernels by changing policy_version to 1
+	in %s.`,
+		err.DirPath, ConfigFileLocation)
+}
+
+// ErrAlreadyProtected indicates that a policy is already protected by the given
+// protector.
+type ErrAlreadyProtected struct {
+	Policy    *Policy
+	Protector *Protector
+}
+
+func (err *ErrAlreadyProtected) Error() string {
+	return fmt.Sprintf("policy %s is already protected by protector %s",
+		err.Policy.Descriptor(), err.Protector.Descriptor())
+}
+
+// ErrDifferentFilesystem indicates that a policy can't be applied to a
+// directory on a different filesystem.
+type ErrDifferentFilesystem struct {
+	PolicyMount *filesystem.Mount
+	PathMount   *filesystem.Mount
+}
+
+func (err *ErrDifferentFilesystem) Error() string {
+	return fmt.Sprintf(`cannot apply policy from filesystem %q to a
+	directory on filesystem %q. Policies may only protect files on the same
+	filesystem.`, err.PolicyMount.Path, err.PathMount.Path)
+}
+
+// ErrMissingPolicyMetadata indicates that a directory is encrypted but its
+// policy metadata cannot be found.
+type ErrMissingPolicyMetadata struct {
+	Mount      *filesystem.Mount
+	DirPath    string
+	Descriptor string
+}
+
+func (err *ErrMissingPolicyMetadata) Error() string {
+	return fmt.Sprintf(`filesystem %q does not contain the policy metadata
+	for %q. This directory has either been encrypted with another tool (such
+	as e4crypt), or the file %q has been deleted.`,
+		err.Mount.Path, err.DirPath,
+		err.Mount.PolicyPath(err.Descriptor))
+}
+
+// ErrNotProtected indicates that the given policy is not protected by the given
+// protector.
+type ErrNotProtected struct {
+	PolicyDescriptor    string
+	ProtectorDescriptor string
+}
+
+func (err *ErrNotProtected) Error() string {
+	return fmt.Sprintf(`policy %s is not protected by protector %s`,
+		err.PolicyDescriptor, err.ProtectorDescriptor)
+}
+
+// ErrOnlyProtector indicates that the last protector can't be removed from a
+// policy.
+type ErrOnlyProtector struct {
+	Policy *Policy
+}
+
+func (err *ErrOnlyProtector) Error() string {
+	return fmt.Sprintf(`cannot remove the only protector from policy %s. A
+	policy must have at least one protector.`, err.Policy.Descriptor())
+}
+
+// ErrPolicyMetadataMismatch indicates that the policy metadata for an encrypted
+// directory is inconsistent with that directory.
+type ErrPolicyMetadataMismatch struct {
+	DirPath   string
+	Mount     *filesystem.Mount
+	PathData  *metadata.PolicyData
+	MountData *metadata.PolicyData
+}
+
+func (err *ErrPolicyMetadataMismatch) Error() string {
+	return fmt.Sprintf(`inconsistent metadata between encrypted directory %q
+	and its corresponding metadata file %q.
+
+	Directory has descriptor:%s %s
+
+	Metadata file has descriptor:%s %s`,
+		err.DirPath, err.Mount.PolicyPath(err.PathData.KeyDescriptor),
+		err.PathData.KeyDescriptor, err.PathData.Options,
+		err.MountData.KeyDescriptor, err.MountData.Options)
+}
 
 // PurgeAllPolicies removes all policy keys on the filesystem from the kernel
 // keyring. In order for this to fully take effect, the filesystem may also need
@@ -161,7 +254,7 @@ func GetPolicyFromPath(ctx *Context, path string) (*Policy, error) {
 		if os.IsPermission(err) &&
 			filesystem.HaveReadAccessTo(path) &&
 			!keyring.IsFsKeyringSupported(ctx.Mount) {
-			return nil, errors.Wrapf(ErrAccessDeniedPossiblyV2, "open %s", path)
+			return nil, &ErrAccessDeniedPossiblyV2{path}
 		}
 		return nil, err
 	}
@@ -171,14 +264,13 @@ func GetPolicyFromPath(ctx *Context, path string) (*Policy, error) {
 	mountData, err := ctx.Mount.GetPolicy(descriptor)
 	if err != nil {
 		log.Printf("getting policy metadata: %v", err)
-		return nil, errors.Wrap(ErrMissingPolicyMetadata, path)
+		return nil, &ErrMissingPolicyMetadata{ctx.Mount, path, descriptor}
 	}
 	log.Printf("found data for policy %s on %q", descriptor, ctx.Mount.Path)
 
-	if !proto.Equal(pathData.Options, mountData.Options) {
-		log.Printf("options from path: %+v", pathData.Options)
-		log.Printf("options from mount: %+v", mountData.Options)
-		return nil, errors.Wrapf(ErrPolicyMetadataMismatch, "policy %s", descriptor)
+	if !proto.Equal(pathData.Options, mountData.Options) ||
+		pathData.KeyDescriptor != mountData.KeyDescriptor {
+		return nil, &ErrPolicyMetadataMismatch{path, ctx.Mount, pathData, mountData}
 	}
 	log.Print("data from filesystem and path agree")
 
@@ -290,7 +382,7 @@ func (policy *Policy) UnlockWithProtector(protector *Protector) error {
 	}
 	idx, ok := policy.findWrappedKeyIndex(protector.Descriptor())
 	if !ok {
-		return ErrNotProtected
+		return &ErrNotProtected{policy.Descriptor(), protector.Descriptor()}
 	}
 
 	var err error
@@ -321,7 +413,7 @@ func (policy *Policy) UsesProtector(protector *Protector) bool {
 // protector must both be unlocked.
 func (policy *Policy) AddProtector(protector *Protector) error {
 	if policy.UsesProtector(protector) {
-		return ErrAlreadyProtected
+		return &ErrAlreadyProtected{policy, protector}
 	}
 	if policy.key == nil || protector.key == nil {
 		return ErrLocked
@@ -372,11 +464,11 @@ func (policy *Policy) AddProtector(protector *Protector) error {
 func (policy *Policy) RemoveProtector(protector *Protector) error {
 	idx, ok := policy.findWrappedKeyIndex(protector.Descriptor())
 	if !ok {
-		return ErrNotProtected
+		return &ErrNotProtected{policy.Descriptor(), protector.Descriptor()}
 	}
 
 	if len(policy.data.WrappedPolicyKeys) == 1 {
-		return ErrOnlyProtector
+		return &ErrOnlyProtector{policy}
 	}
 
 	// Remove the wrapped key from the data
@@ -397,7 +489,7 @@ func (policy *Policy) Apply(path string) error {
 	if pathMount, err := filesystem.FindMount(path); err != nil {
 		return err
 	} else if pathMount != policy.Context.Mount {
-		return ErrDifferentFilesystem
+		return &ErrDifferentFilesystem{policy.Context.Mount, pathMount}
 	}
 
 	return metadata.SetPolicy(path, policy.data)

--- a/actions/recovery.go
+++ b/actions/recovery.go
@@ -23,8 +23,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/pkg/errors"
-
 	"github.com/google/fscrypt/crypto"
 	"github.com/google/fscrypt/metadata"
 )
@@ -72,7 +70,7 @@ func AddRecoveryPassphrase(policy *Policy, dirname string) (*crypto.Key, *Protec
 		if err == nil {
 			break
 		}
-		if errors.Cause(err) != ErrDuplicateName {
+		if _, ok := err.(*ErrProtectorNameExists); !ok {
 			return nil, nil, err
 		}
 		seq++

--- a/cli-tests/t_encrypt.out
+++ b/cli-tests/t_encrypt.out
@@ -3,8 +3,8 @@
 [ERROR] fscrypt encrypt: no such file or directory
 ext4 filesystem "MNT" has 0 protectors and 0 policies
 
-[ERROR] fscrypt status: get encryption policy MNT/dir: file
-                        or directory not encrypted
+[ERROR] fscrypt status: file or directory "MNT/dir" is not
+                        encrypted
 
 # Try to encrypt a nonempty directory
 [ERROR] fscrypt encrypt: MNT/dir: not an empty directory
@@ -14,8 +14,8 @@ in-place. Instead, encrypt an empty directory, copy the files into that
 encrypted directory, and securely delete the originals with "shred".
 ext4 filesystem "MNT" has 0 protectors and 0 policies
 
-[ERROR] fscrypt status: get encryption policy MNT/dir: file
-                        or directory not encrypted
+[ERROR] fscrypt status: file or directory "MNT/dir" is not
+                        encrypted
 
 # Encrypt a directory as non-root user
 ext4 filesystem "MNT" has 1 protector and 1 policy
@@ -52,16 +52,16 @@ PROTECTOR         LINKED  DESCRIPTION
 desc1  No      custom protector "prot"
 
 # Try to encrypt an already-encrypted directory
-[ERROR] fscrypt encrypt: MNT/dir: file or directory already
-                         encrypted
+[ERROR] fscrypt encrypt: file or directory "MNT/dir" is
+                         already encrypted
 
 # Try to encrypt another user's directory as a non-root user
-[ERROR] fscrypt encrypt: MNT/dir: you do not own this
-                         directory
+[ERROR] fscrypt encrypt: cannot encrypt "MNT/dir" because
+                         it's owned by another user (root).
 
-Encryption can only be setup on directories you own, even if you have write
-permission for the directory.
+                         Encryption can only be enabled on a directory you own,
+                         even if you have write access to the directory.
 ext4 filesystem "MNT" has 0 protectors and 0 policies
 
-[ERROR] fscrypt status: get encryption policy MNT/dir: file
-                        or directory not encrypted
+[ERROR] fscrypt status: file or directory "MNT/dir" is not
+                        encrypted

--- a/cli-tests/t_encrypt.out
+++ b/cli-tests/t_encrypt.out
@@ -7,11 +7,22 @@ ext4 filesystem "MNT" has 0 protectors and 0 policies
                         encrypted
 
 # Try to encrypt a nonempty directory
-[ERROR] fscrypt encrypt: MNT/dir: not an empty directory
+[ERROR] fscrypt encrypt: Directory "MNT/dir" cannot be
+                         encrypted because it is non-empty.
 
-Encryption can only be setup on empty directories; files cannot be encrypted
-in-place. Instead, encrypt an empty directory, copy the files into that
-encrypted directory, and securely delete the originals with "shred".
+Files cannot be encrypted in-place. Instead, encrypt a new directory, copy the
+files into it, and securely delete the original directory. For example:
+
+     mkdir MNT/dir.new
+     fscrypt encrypt MNT/dir.new
+     cp -a -T MNT/dir MNT/dir.new
+     find MNT/dir -type f -print0 | xargs -0 shred -n1 --remove=unlink
+     rm -rf MNT/dir
+     mv MNT/dir.new MNT/dir
+
+Caution: due to the nature of modern storage devices and filesystems, the
+original data may still be recoverable from disk. It's much better to encrypt
+your files from the start.
 ext4 filesystem "MNT" has 0 protectors and 0 policies
 
 [ERROR] fscrypt status: file or directory "MNT/dir" is not

--- a/cli-tests/t_encrypt_custom.out
+++ b/cli-tests/t_encrypt_custom.out
@@ -51,5 +51,5 @@ desc6  No      custom protector "prot"
 Use --name=PROTECTOR_NAME to specify a protector name.
 ext4 filesystem "MNT" has 0 protectors and 0 policies
 
-[ERROR] fscrypt status: get encryption policy MNT/dir: file
-                        or directory not encrypted
+[ERROR] fscrypt status: file or directory "MNT/dir" is not
+                        encrypted

--- a/cli-tests/t_encrypt_custom.out
+++ b/cli-tests/t_encrypt_custom.out
@@ -46,7 +46,7 @@ PROTECTOR         LINKED  DESCRIPTION
 desc6  No      custom protector "prot"
 
 # Try to use a custom protector without a name
-[ERROR] fscrypt encrypt: custom protectors must have a name
+[ERROR] fscrypt encrypt: custom_passphrase protectors must be named
 
 Use --name=PROTECTOR_NAME to specify a protector name.
 ext4 filesystem "MNT" has 0 protectors and 0 policies

--- a/cli-tests/t_encrypt_login.out
+++ b/cli-tests/t_encrypt_login.out
@@ -139,8 +139,8 @@ ext4 filesystem "MNT" has 0 protectors and 0 policies
 
 ext4 filesystem "MNT_ROOT" has 0 protectors and 0 policies
 
-[ERROR] fscrypt status: get encryption policy MNT/dir: file
-                        or directory not encrypted
+[ERROR] fscrypt status: file or directory "MNT/dir" is not
+                        encrypted
 
 # Try to use the wrong login passphrase
 [ERROR] fscrypt encrypt: incorrect login passphrase
@@ -148,5 +148,5 @@ ext4 filesystem "MNT" has 0 protectors and 0 policies
 
 ext4 filesystem "MNT_ROOT" has 0 protectors and 0 policies
 
-[ERROR] fscrypt status: get encryption policy MNT/dir: file
-                        or directory not encrypted
+[ERROR] fscrypt status: file or directory "MNT/dir" is not
+                        encrypted

--- a/cli-tests/t_encrypt_login.out
+++ b/cli-tests/t_encrypt_login.out
@@ -130,7 +130,11 @@ POLICY                            UNLOCKED  PROTECTORS
 desc34  Yes       desc35
 
 # Try to give a login protector a name
-[ERROR] fscrypt encrypt: login protectors do not need a name
+[ERROR] fscrypt encrypt: cannot assign name "prot" to new login protector for
+                         user "fscrypt-test-user" because login protectors are
+                         identified by user, not by name.
+
+To fix this, don't specify the --name=PROTECTOR_NAME option.
 ext4 filesystem "MNT" has 0 protectors and 0 policies
 
 ext4 filesystem "MNT_ROOT" has 0 protectors and 0 policies

--- a/cli-tests/t_encrypt_raw_key.out
+++ b/cli-tests/t_encrypt_raw_key.out
@@ -21,5 +21,5 @@ desc1  No      raw key protector "prot"
 [ERROR] fscrypt encrypt: TMPDIR/raw_key: key file must be 32 bytes
 ext4 filesystem "MNT" has 0 protectors and 0 policies
 
-[ERROR] fscrypt status: get encryption policy MNT/dir: file
-                        or directory not encrypted
+[ERROR] fscrypt status: file or directory "MNT/dir" is not
+                        encrypted

--- a/cli-tests/t_lock.out
+++ b/cli-tests/t_lock.out
@@ -33,11 +33,16 @@ desc2  No      custom protector "prot"
 contents
 
 # Try to lock directory while files busy
-[ERROR] fscrypt lock: some files using the key are still open
+[ERROR] fscrypt lock: Directory was incompletely locked because some files are
+                      still open. These files remain accessible.
 
-Directory was incompletely locked because some files are still open. These files
-remain accessible. Try killing any processes using files in the directory, then
-re-running 'fscrypt lock'.
+Try killing any processes using files in the directory, for example using:
+
+     find "MNT/dir" -print0 | xargs -0 fuser -k
+
+Then re-run:
+
+     fscrypt lock "MNT/dir"
 
 # => status should be incompletely locked
 "MNT/dir" is encrypted with fscrypt.
@@ -72,11 +77,12 @@ mkdir: cannot create directory 'MNT/dir/subdir': Required key not available
 
 # Try to lock directory while other user has unlocked
 Enter custom passphrase for protector "prot": "MNT/dir" is now unlocked and ready for use.
-[ERROR] fscrypt lock: other users have added the key too
+[ERROR] fscrypt lock: Directory "MNT/dir" couldn't be fully
+                      locked because other user(s) have unlocked it.
 
-Directory couldn't be fully locked because other user(s) have unlocked it. If
-you want to force the directory to be locked, use 'sudo fscrypt lock --all-users
-DIR'.
+If you want to force the directory to be locked, use:
+
+     sudo fscrypt lock --all-users "MNT/dir"
 contents
 "MNT/dir" is now locked.
 cat: MNT/dir/file: No such file or directory

--- a/cli-tests/t_not_enabled.out
+++ b/cli-tests/t_not_enabled.out
@@ -2,24 +2,21 @@
 # Disable encryption on DEV
 
 # Try to encrypt a directory when encryption is disabled
-[ERROR] fscrypt encrypt: get encryption policy MNT/dir:
-                         encryption not enabled
+[ERROR] fscrypt encrypt: encryption not enabled
 
 Encryption is either disabled in the kernel config, or needs to be enabled for
 this filesystem. See the documentation on how to enable encryption on ext4
 systems (and the risks of doing so).
 
 # Try to unlock a directory when encryption is disabled
-[ERROR] fscrypt unlock: get encryption policy MNT/dir:
-                        encryption not enabled
+[ERROR] fscrypt unlock: encryption not enabled
 
 Encryption is either disabled in the kernel config, or needs to be enabled for
 this filesystem. See the documentation on how to enable encryption on ext4
 systems (and the risks of doing so).
 
 # Try to lock a directory when encryption is disabled
-[ERROR] fscrypt lock: get encryption policy MNT/dir:
-                      encryption not enabled
+[ERROR] fscrypt lock: encryption not enabled
 
 Encryption is either disabled in the kernel config, or needs to be enabled for
 this filesystem. See the documentation on how to enable encryption on ext4

--- a/cli-tests/t_not_enabled.out
+++ b/cli-tests/t_not_enabled.out
@@ -2,25 +2,52 @@
 # Disable encryption on DEV
 
 # Try to encrypt a directory when encryption is disabled
-[ERROR] fscrypt encrypt: encryption not enabled
+[ERROR] fscrypt encrypt: encryption not enabled on filesystem
+                         MNT (DEV).
 
-Encryption is either disabled in the kernel config, or needs to be enabled for
-this filesystem. See the documentation on how to enable encryption on ext4
-systems (and the risks of doing so).
+To enable encryption support on this filesystem, run:
+
+     sudo tune2fs -O encrypt "DEV"
+
+Also ensure that your kernel has CONFIG_FS_ENCRYPTION=y. See the documentation
+for more details.
 
 # Try to unlock a directory when encryption is disabled
-[ERROR] fscrypt unlock: encryption not enabled
+[ERROR] fscrypt unlock: encryption not enabled on filesystem
+                        MNT (DEV).
 
-Encryption is either disabled in the kernel config, or needs to be enabled for
-this filesystem. See the documentation on how to enable encryption on ext4
-systems (and the risks of doing so).
+To enable encryption support on this filesystem, run:
+
+     sudo tune2fs -O encrypt "DEV"
+
+Also ensure that your kernel has CONFIG_FS_ENCRYPTION=y. See the documentation
+for more details.
 
 # Try to lock a directory when encryption is disabled
-[ERROR] fscrypt lock: encryption not enabled
+[ERROR] fscrypt lock: encryption not enabled on filesystem
+                      MNT (DEV).
 
-Encryption is either disabled in the kernel config, or needs to be enabled for
-this filesystem. See the documentation on how to enable encryption on ext4
-systems (and the risks of doing so).
+To enable encryption support on this filesystem, run:
+
+     sudo tune2fs -O encrypt "DEV"
+
+Also ensure that your kernel has CONFIG_FS_ENCRYPTION=y. See the documentation
+for more details.
+
+# Check for additional message when GRUB appears to be installed
+[ERROR] fscrypt encrypt: encryption not enabled on filesystem
+                         MNT (DEV).
+
+To enable encryption support on this filesystem, run:
+
+     sudo tune2fs -O encrypt "DEV"
+
+WARNING: you seem to have GRUB installed on this filesystem. Before doing the
+above, make sure you are using GRUB v2.04 or later; otherwise your system will
+become unbootable.
+
+Also ensure that your kernel has CONFIG_FS_ENCRYPTION=y. See the documentation
+for more details.
 
 # Enable encryption on DEV
 

--- a/cli-tests/t_not_enabled.sh
+++ b/cli-tests/t_not_enabled.sh
@@ -26,6 +26,11 @@ _expect_failure "fscrypt unlock '$dir'"
 _print_header "Try to lock a directory when encryption is disabled"
 _expect_failure "fscrypt lock '$dir'"
 
+_print_header "Check for additional message when GRUB appears to be installed"
+mkdir -p "$MNT/boot/grub"
+_expect_failure "fscrypt encrypt '$dir'"
+rm -r "${MNT:?}/boot"
+
 _print_header "Enable encryption on $DEV"
 _run_noisy_command "tune2fs -O encrypt '$DEV'"
 

--- a/cli-tests/t_not_supported.out
+++ b/cli-tests/t_not_supported.out
@@ -5,7 +5,6 @@
 Metadata directories created at "MNT/.fscrypt".
 
 # Try to encrypt a directory on tmpfs
-[ERROR] fscrypt encrypt: get encryption policy MNT/dir:
-                         encryption not supported
+[ERROR] fscrypt encrypt: encryption not supported
 
 Encryption for this type of filesystem is not supported on this kernel version.

--- a/cli-tests/t_not_supported.out
+++ b/cli-tests/t_not_supported.out
@@ -5,6 +5,5 @@
 Metadata directories created at "MNT/.fscrypt".
 
 # Try to encrypt a directory on tmpfs
-[ERROR] fscrypt encrypt: encryption not supported
-
-Encryption for this type of filesystem is not supported on this kernel version.
+[ERROR] fscrypt encrypt: This kernel doesn't support encryption on tmpfs
+                         filesystems.

--- a/cli-tests/t_setup.out
+++ b/cli-tests/t_setup.out
@@ -38,12 +38,12 @@ Metadata directories created at "MNT/.fscrypt".
                        with fscrypt
 
 # no config file
-[ERROR] fscrypt setup: global config file does not exist
+[ERROR] fscrypt setup: "FSCRYPT_CONF" doesn't exist
 
-Run "sudo fscrypt setup" to create the file.
+Run "sudo fscrypt setup" to create this file.
 
 # bad config file
-[ERROR] fscrypt setup: invalid character 'b' looking for beginning of value:
-                       global config file has invalid data
+[ERROR] fscrypt setup: "FSCRYPT_CONF" is invalid: invalid
+                       character 'b' looking for beginning of value
 
-Run "sudo fscrypt setup" to recreate the file.
+Either fix this file manually, or run "sudo fscrypt setup" to recreate it.

--- a/cli-tests/t_setup.out
+++ b/cli-tests/t_setup.out
@@ -34,8 +34,8 @@ Use --force to automatically run destructive operations.
 Metadata directories created at "MNT/.fscrypt".
 
 # fscrypt setup filesystem (already set up)
-[ERROR] fscrypt setup: filesystem MNT: already setup for use
-                       with fscrypt
+[ERROR] fscrypt setup: filesystem MNT is already setup for
+                       use with fscrypt
 
 # no config file
 [ERROR] fscrypt setup: "FSCRYPT_CONF" doesn't exist

--- a/cli-tests/t_setup.out
+++ b/cli-tests/t_setup.out
@@ -26,7 +26,7 @@ Skipping creating MNT_ROOT/.fscrypt because it already exists.
 # fscrypt setup --quiet when fscrypt.conf already exists
 [ERROR] fscrypt setup: operation would be destructive
 
-Use --force to automatically run destructive operations.
+If desired, use --force to automatically run destructive operations.
 
 # fscrypt setup --quiet --force when fscrypt.conf already exists
 

--- a/cli-tests/t_status.out
+++ b/cli-tests/t_status.out
@@ -10,10 +10,10 @@ ext4 filesystem "MNT" has 0 protectors and 0 policies
 
 
 # Get status of unencrypted directory on setup mountpoint
-[ERROR] fscrypt status: get encryption policy MNT/dir: file
-                        or directory not encrypted
-[ERROR] fscrypt status: get encryption policy MNT/dir: file
-                        or directory not encrypted
+[ERROR] fscrypt status: file or directory "MNT/dir" is not
+                        encrypted
+[ERROR] fscrypt status: file or directory "MNT/dir" is not
+                        encrypted
 
 # Remove fscrypt metadata from MNT
 

--- a/cli-tests/t_status.out
+++ b/cli-tests/t_status.out
@@ -24,21 +24,25 @@ ext4 supported No
 ext4 supported No
 
 # Get status of not-setup mountpoint
-[ERROR] fscrypt status: filesystem MNT: not setup for use
+[ERROR] fscrypt status: filesystem MNT is not setup for use
                         with fscrypt
 
-Run "fscrypt setup MOUNTPOINT" to use fscrypt on this filesystem.
-[ERROR] fscrypt status: filesystem MNT: not setup for use
+Run "sudo fscrypt setup MNT" to use fscrypt on this
+filesystem.
+[ERROR] fscrypt status: filesystem MNT is not setup for use
                         with fscrypt
 
-Run "fscrypt setup MOUNTPOINT" to use fscrypt on this filesystem.
+Run "sudo fscrypt setup MNT" to use fscrypt on this
+filesystem.
 
 # Get status of unencrypted directory on not-setup mountpoint
-[ERROR] fscrypt status: filesystem MNT: not setup for use
+[ERROR] fscrypt status: filesystem MNT is not setup for use
                         with fscrypt
 
-Run "fscrypt setup MOUNTPOINT" to use fscrypt on this filesystem.
-[ERROR] fscrypt status: filesystem MNT: not setup for use
+Run "sudo fscrypt setup MNT" to use fscrypt on this
+filesystem.
+[ERROR] fscrypt status: filesystem MNT is not setup for use
                         with fscrypt
 
-Run "fscrypt setup MOUNTPOINT" to use fscrypt on this filesystem.
+Run "sudo fscrypt setup MNT" to use fscrypt on this
+filesystem.

--- a/cli-tests/t_unlock.out
+++ b/cli-tests/t_unlock.out
@@ -81,12 +81,9 @@ contents
 desc1  Yes       desc2
 
 # Try to unlock with corrupt policy metadata
-[ERROR] fscrypt unlock: filesystem "MNT" does not contain
-                        the policy metadata for "MNT/dir".
-                        This directory has either been encrypted with another
-                        tool (such as e4crypt), or the file
+[ERROR] fscrypt unlock: fscrypt metadata file at
                         "MNT/.fscrypt/policies/desc1"
-                        has been deleted.
+                        is corrupt: unexpected EOF
 
 # Try to unlock with missing policy metadata
 [ERROR] fscrypt unlock: filesystem "MNT" does not contain

--- a/cli-tests/t_unlock.out
+++ b/cli-tests/t_unlock.out
@@ -81,21 +81,39 @@ contents
 desc1  Yes       desc2
 
 # Try to unlock with corrupt policy metadata
-[ERROR] fscrypt unlock: MNT/dir: system error: missing
-                        policy metadata for encrypted directory
-
-This file or directory has either been encrypted with another tool (such as
-e4crypt) or the corresponding filesystem metadata has been deleted.
+[ERROR] fscrypt unlock: filesystem "MNT" does not contain
+                        the policy metadata for "MNT/dir".
+                        This directory has either been encrypted with another
+                        tool (such as e4crypt), or the file
+                        "MNT/.fscrypt/policies/desc1"
+                        has been deleted.
 
 # Try to unlock with missing policy metadata
-[ERROR] fscrypt unlock: MNT/dir: system error: missing
-                        policy metadata for encrypted directory
-
-This file or directory has either been encrypted with another tool (such as
-e4crypt) or the corresponding filesystem metadata has been deleted.
+[ERROR] fscrypt unlock: filesystem "MNT" does not contain
+                        the policy metadata for "MNT/dir".
+                        This directory has either been encrypted with another
+                        tool (such as e4crypt), or the file
+                        "MNT/.fscrypt/policies/desc20"
+                        has been deleted.
 
 # Try to unlock with missing protector metadata
 [ERROR] fscrypt unlock: could not load any protectors
 
 You may need to mount a linked filesystem. Run with --verbose for more
 information.
+
+# Try to unlock with wrong policy metadata
+[ERROR] fscrypt unlock: inconsistent metadata between encrypted directory
+                        "MNT/dir1" and its corresponding
+                        metadata file
+                        "MNT/.fscrypt/policies/desc21".
+
+                        Directory has
+                        descriptor:desc21 padding:32
+                        contents:AES_256_XTS filenames:AES_256_CTS
+                        policy_version:2
+
+                        Metadata file has
+                        descriptor:desc23 padding:32
+                        contents:AES_256_XTS filenames:AES_256_CTS
+                        policy_version:2

--- a/cli-tests/t_unlock.sh
+++ b/cli-tests/t_unlock.sh
@@ -67,3 +67,16 @@ mkdir "$dir"
 echo hunter2 | fscrypt encrypt --quiet --name=prot --skip-unlock "$dir"
 rm "$MNT"/.fscrypt/protectors/*
 _expect_failure "echo hunter2 | fscrypt unlock '$dir'"
+
+_print_header "Try to unlock with wrong policy metadata"
+_reset_filesystems
+mkdir "$MNT/dir1"
+mkdir "$MNT/dir2"
+echo hunter2 | fscrypt encrypt --quiet --name=dir1 --skip-unlock "$MNT/dir1"
+echo hunter2 | fscrypt encrypt --quiet --name=dir2 --skip-unlock "$MNT/dir2"
+policy1=$(find "$MNT/.fscrypt/policies/" -type f | head -1)
+policy2=$(find "$MNT/.fscrypt/policies/" -type f | tail -1)
+mv "$policy1" "$TMPDIR/policy"
+mv "$policy2" "$policy1"
+mv "$TMPDIR/policy" "$policy2"
+_expect_failure "echo hunter2 | fscrypt unlock '$MNT/dir1'"

--- a/cli-tests/t_v1_policy.out
+++ b/cli-tests/t_v1_policy.out
@@ -11,14 +11,15 @@ can be done with --user=USERNAME. To use the root user's keyring or passphrase,
 use --user=root.
 
 # Try to use --user=root as user
-[ERROR] fscrypt encrypt: setting uids: operation not permitted: could not access
-                         user keyring
+[ERROR] fscrypt encrypt: could not access user keyring for "root": setting uids:
+                         operation not permitted
 
 You can only use --user=USERNAME to access the user keyring of another user if
 you are running as root.
 
 # Try to encrypt without user keyring in session keyring
-[ERROR] fscrypt encrypt: user keyring not linked into session keyring
+[ERROR] fscrypt encrypt: user keyring for "fscrypt-test-user" is not linked into
+                         the session keyring
 
 This is usually the result of a bad PAM configuration. Either correct the
 problem in your PAM stack, enable pam_keyinit.so, or run "keyctl link @u @s".

--- a/cli-tests/t_v1_policy.out
+++ b/cli-tests/t_v1_policy.out
@@ -101,11 +101,16 @@ cat: MNT/dir/file: No such file or directory
 # Testing incompletely locking v1-encrypted directory
 Enter custom passphrase for protector "prot": "MNT/dir" is now unlocked and ready for use.
 Encrypted data removed from filesystem cache.
-[ERROR] fscrypt lock: some files using the key are still open
+[ERROR] fscrypt lock: Directory was incompletely locked because some files are
+                      still open. These files remain accessible.
 
-Directory was incompletely locked because some files are still open. These files
-remain accessible. Try killing any processes using files in the directory, then
-re-running 'fscrypt lock'.
+Try killing any processes using files in the directory, for example using:
+
+     find "MNT/dir" -print0 | xargs -0 fuser -k
+
+Then re-run:
+
+     fscrypt lock "MNT/dir"
 "MNT/dir" is encrypted with fscrypt.
 
 Policy:   desc1

--- a/cli-tests/t_v1_policy_fs_keyring.out
+++ b/cli-tests/t_v1_policy_fs_keyring.out
@@ -10,8 +10,8 @@ Either this command should be run as root, or you should set
 re-create your encrypted directories using v2 encryption policies rather than v1
 (this requires setting '"policy_version": "2"' in the "options" section of
 /etc/fscrypt.conf).
-[ERROR] fscrypt status: get encryption policy MNT/dir: file
-                        or directory not encrypted
+[ERROR] fscrypt status: file or directory "MNT/dir" is not
+                        encrypted
 
 # Encrypt directory as user with --skip-unlock
 "MNT/dir" is encrypted with fscrypt.

--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -82,6 +82,10 @@ func getErrorSuggestions(err error) string {
 	switch err.(type) {
 	case *actions.ErrBadConfigFile:
 		return `Either fix this file manually, or run "sudo fscrypt setup" to recreate it.`
+	case *actions.ErrLoginProtectorName:
+		return fmt.Sprintf("To fix this, don't specify the %s option.", shortDisplay(nameFlag))
+	case *actions.ErrMissingProtectorName:
+		return fmt.Sprintf("Use %s to specify a protector name.", shortDisplay(nameFlag))
 	case *actions.ErrNoConfigFile:
 		return `Run "sudo fscrypt setup" to create this file.`
 	}
@@ -131,8 +135,6 @@ func getErrorSuggestions(err error) string {
 		return `The metadata for this encrypted directory is in an
 			inconsistent state. This most likely means the filesystem
 			metadata is corrupted.`
-	case actions.ErrMissingProtectorName:
-		return fmt.Sprintf("Use %s to specify a protector name.", shortDisplay(nameFlag))
 	case actions.ErrAccessDeniedPossiblyV2:
 		return fmt.Sprintf(`This may be caused by the directory using a v2
 		encryption policy and the current kernel not supporting it. If

--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -127,21 +127,6 @@ func getErrorSuggestions(err error) string {
 		return fmt.Sprintf(`v2 encryption policies are only supported by kernel
 		version 5.4 and later. Either use a newer kernel, or change
 		policy_version to 1 in %s.`, actions.ConfigFileLocation)
-	case actions.ErrMissingPolicyMetadata:
-		return `This file or directory has either been encrypted with
-			another tool (such as e4crypt) or the corresponding
-			filesystem metadata has been deleted.`
-	case actions.ErrPolicyMetadataMismatch:
-		return `The metadata for this encrypted directory is in an
-			inconsistent state. This most likely means the filesystem
-			metadata is corrupted.`
-	case actions.ErrAccessDeniedPossiblyV2:
-		return fmt.Sprintf(`This may be caused by the directory using a v2
-		encryption policy and the current kernel not supporting it. If
-		indeed the case, then this directory can only be used on kernel
-		v5.4 and later. You can create directories accessible on older
-		kernels by changing policy_version to 1 in %s.`,
-			actions.ConfigFileLocation)
 	case ErrNoDestructiveOps:
 		return fmt.Sprintf("Use %s to automatically run destructive operations.", shortDisplay(forceFlag))
 	case ErrSpecifyProtector:

--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -47,7 +47,6 @@ const failureExitCode = 1
 var (
 	ErrCanceled           = errors.New("operation canceled")
 	ErrNoDestructiveOps   = errors.New("operation would be destructive")
-	ErrMaxPassphrase      = util.SystemError("max passphrase length exceeded")
 	ErrInvalidSource      = errors.New("invalid source type")
 	ErrPassphraseMismatch = errors.New("entered passphrases do not match")
 	ErrSpecifyProtector   = errors.New("multiple protectors available")

--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -92,7 +92,7 @@ func getErrorSuggestions(err error) string {
 	switch errors.Cause(err) {
 	case filesystem.ErrNotSetup:
 		return fmt.Sprintf(`Run "fscrypt setup %s" to use fscrypt on this filesystem.`, mountpointArg)
-	case crypto.ErrKeyLock:
+	case crypto.ErrMlockUlimit:
 		return `Too much memory was requested to be locked in RAM. The
 			current limit for this user can be checked with "ulimit
 			-l". The limit can be modified by either changing the

--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -57,7 +57,6 @@ var (
 	ErrMustBeRoot         = errors.New("this command must be run as root")
 	ErrPolicyUnlocked     = errors.New("this file or directory is already unlocked")
 	ErrPolicyLocked       = errors.New("this file or directory is already locked")
-	ErrBadOwners          = errors.New("you do not own this directory")
 	ErrNotEmptyDir        = errors.New("not an empty directory")
 	ErrNotPassphrase      = errors.New("protector does not use a passphrase")
 	ErrUnknownUser        = errors.New("unknown user")
@@ -133,9 +132,6 @@ func getErrorSuggestions(err error) string {
 		return fmt.Sprintf("Use %s to specify a protector.", shortDisplay(protectorFlag))
 	case ErrSpecifyKeyFile:
 		return fmt.Sprintf("Use %s to specify a key file.", shortDisplay(keyFileFlag))
-	case ErrBadOwners:
-		return `Encryption can only be setup on directories you own,
-			even if you have write permission for the directory.`
 	case ErrNotEmptyDir:
 		return `Encryption can only be setup on empty directories; files
 			cannot be encrypted in-place. Instead, encrypt an empty

--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -79,6 +79,12 @@ func getFullName(c *cli.Context) string {
 // getErrorSuggestions returns a string containing suggestions about how to fix
 // an error. If no suggestion is necessary or available, return empty string.
 func getErrorSuggestions(err error) string {
+	switch err.(type) {
+	case *actions.ErrBadConfigFile:
+		return `Either fix this file manually, or run "sudo fscrypt setup" to recreate it.`
+	case *actions.ErrNoConfigFile:
+		return `Run "sudo fscrypt setup" to create this file.`
+	}
 	switch errors.Cause(err) {
 	case filesystem.ErrNotSetup:
 		return fmt.Sprintf(`Run "fscrypt setup %s" to use fscrypt on this filesystem.`, mountpointArg)
@@ -117,10 +123,6 @@ func getErrorSuggestions(err error) string {
 		return fmt.Sprintf(`v2 encryption policies are only supported by kernel
 		version 5.4 and later. Either use a newer kernel, or change
 		policy_version to 1 in %s.`, actions.ConfigFileLocation)
-	case actions.ErrBadConfigFile:
-		return `Run "sudo fscrypt setup" to recreate the file.`
-	case actions.ErrNoConfigFile:
-		return `Run "sudo fscrypt setup" to create the file.`
 	case actions.ErrMissingPolicyMetadata:
 		return `This file or directory has either been encrypted with
 			another tool (such as e4crypt) or the corresponding

--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -88,6 +88,14 @@ func getErrorSuggestions(err error) string {
 		return fmt.Sprintf("Use %s to specify a protector name.", shortDisplay(nameFlag))
 	case *actions.ErrNoConfigFile:
 		return `Run "sudo fscrypt setup" to create this file.`
+	case *keyring.ErrAccessUserKeyring:
+		return fmt.Sprintf(`You can only use %s to access the user
+			keyring of another user if you are running as root.`,
+			shortDisplay(userFlag))
+	case *keyring.ErrSessionUserKeyring:
+		return `This is usually the result of a bad PAM configuration.
+			Either correct the problem in your PAM stack, enable
+			pam_keyinit.so, or run "keyctl link @u @s".`
 	}
 	switch errors.Cause(err) {
 	case filesystem.ErrNotSetup:
@@ -115,14 +123,6 @@ func getErrorSuggestions(err error) string {
 		return `Directory couldn't be fully locked because other user(s)
 			have unlocked it. If you want to force the directory to
 			be locked, use 'sudo fscrypt lock --all-users DIR'.`
-	case keyring.ErrSessionUserKeying:
-		return `This is usually the result of a bad PAM configuration.
-			Either correct the problem in your PAM stack, enable
-			pam_keyinit.so, or run "keyctl link @u @s".`
-	case keyring.ErrAccessUserKeyring:
-		return fmt.Sprintf(`You can only use %s to access the user
-			keyring of another user if you are running as root.`,
-			shortDisplay(userFlag))
 	case keyring.ErrV2PoliciesUnsupported:
 		return fmt.Sprintf(`v2 encryption policies are only supported by kernel
 		version 5.4 and later. Either use a newer kernel, or change

--- a/cmd/fscrypt/format.go
+++ b/cmd/fscrypt/format.go
@@ -121,7 +121,8 @@ func longDisplay(f prettyFlag, defaultString ...string) string {
 // Takes an input string text, and wraps the text so that each line begins with
 // padding spaces (except for the first line), ends with a newline (except the
 // last line), and each line has length less than lineLength. If the text
-// contains a word which is too long, that word gets its own line.
+// contains a word which is too long, that word gets its own line. Paragraphs
+// and "code blocks" are preserved.
 func wrapText(text string, padding int) string {
 	// We use a buffer to format the wrapped text so we get O(n) runtime
 	var buffer bytes.Buffer
@@ -141,10 +142,18 @@ func wrapText(text string, padding int) string {
 			continue
 		}
 
+		codeBlock := (words[0] == ">")
+		if codeBlock {
+			words[0] = "    "
+			if filled != 0 {
+				buffer.WriteString("\n")
+				filled = 0
+			}
+		}
 		for _, word := range words {
 			wordLen := utf8.RuneCountInString(word)
 			// Write a newline if needed.
-			if filled != 0 && filled+1+wordLen > lineLength {
+			if filled != 0 && filled+1+wordLen > lineLength && !codeBlock {
 				buffer.WriteString("\n")
 				filled = 0
 			}

--- a/cmd/fscrypt/keys.go
+++ b/cmd/fscrypt/keys.go
@@ -55,14 +55,14 @@ var (
 // struct is empty as the reader needs to maintain no internal state.
 type passphraseReader struct{}
 
-// Read gets input from the terminal until a newline is encountered. This read
-// should be called with the maximum buffer size for the passphrase.
+// Read gets input from the terminal until a newline is encountered or the given
+// buffer is full.
 func (p passphraseReader) Read(buf []byte) (int, error) {
 	// We read one byte at a time to handle backspaces
 	position := 0
 	for {
 		if position == len(buf) {
-			return position, ErrMaxPassphrase
+			return position, nil
 		}
 		if _, err := io.ReadFull(os.Stdin, buf[position:position+1]); err != nil {
 			return position, err

--- a/cmd/fscrypt/prompt.go
+++ b/cmd/fscrypt/prompt.go
@@ -318,7 +318,8 @@ func optionFn(policyDescriptor string, options []*actions.ProtectorOption) (int,
 				return idx, nil
 			}
 		}
-		return 0, actions.ErrNotProtected
+		return 0, &actions.ErrNotProtected{PolicyDescriptor: policyDescriptor,
+			ProtectorDescriptor: protector.Descriptor()}
 	}
 
 	log.Printf("optionFn(%s)", policyDescriptor)

--- a/cmd/fscrypt/status.go
+++ b/cmd/fscrypt/status.go
@@ -27,12 +27,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/pkg/errors"
-
 	"github.com/google/fscrypt/actions"
 	"github.com/google/fscrypt/filesystem"
 	"github.com/google/fscrypt/keyring"
-	"github.com/google/fscrypt/metadata"
 )
 
 // Creates a writer which correctly aligns tabs with the specified header.
@@ -46,12 +43,13 @@ func makeTableWriter(w io.Writer, header string) *tabwriter.Writer {
 // encryptionStatus will be printed in the ENCRYPTION column. An empty string
 // indicates the filesystem should not be printed.
 func encryptionStatus(err error) string {
-	switch errors.Cause(err) {
-	case nil:
+	if err == nil {
 		return "supported"
-	case metadata.ErrEncryptionNotEnabled:
+	}
+	switch err.(type) {
+	case *filesystem.ErrEncryptionNotEnabled:
 		return "not enabled"
-	case metadata.ErrEncryptionNotSupported:
+	case *filesystem.ErrEncryptionNotSupported:
 		return "not supported"
 	default:
 		// Unknown error regarding support

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -50,13 +50,9 @@ import (
 
 // Crypto error values
 var (
-	ErrBadAuth        = errors.New("key authentication check failed")
-	ErrNegativeLength = errors.New("keys cannot have negative lengths")
-	ErrRecoveryCode   = errors.New("invalid recovery code")
-	ErrGetrandomFail  = util.SystemError("getrandom() failed")
-	ErrKeyAlloc       = util.SystemError("could not allocate memory for key")
-	ErrKeyFree        = util.SystemError("could not free memory of key")
-	ErrKeyLock        = errors.New("could not lock key in memory")
+	ErrBadAuth      = errors.New("key authentication check failed")
+	ErrRecoveryCode = errors.New("invalid recovery code")
+	ErrMlockUlimit  = errors.New("could not lock key in memory")
 )
 
 // panicInputLength panics if "name" has invalid length (expected != actual)

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -257,7 +257,7 @@ func TestBigKeyGen(t *testing.T) {
 	case nil:
 		key.Wipe()
 		return
-	case ErrKeyLock:
+	case ErrMlockUlimit:
 		// Don't fail just because "ulimit -l" is too low.
 		return
 	default:

--- a/crypto/rand.go
+++ b/crypto/rand.go
@@ -90,10 +90,9 @@ func (r randReader) Read(buffer []byte) (int, error) {
 	case nil:
 		return n, nil
 	case unix.EAGAIN:
-		return 0, errors.Wrap(ErrGetrandomFail, "insufficient entropy in pool")
+		err = errors.New("insufficient entropy in pool")
 	case unix.ENOSYS:
-		return 0, errors.Wrap(ErrGetrandomFail, "kernel must be v3.17 or later")
-	default:
-		return 0, errors.Wrap(ErrGetrandomFail, err.Error())
+		err = errors.New("kernel must be v3.17 or later")
 	}
+	return 0, errors.Wrap(err, "getrandom() failed")
 }

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -181,9 +181,9 @@ func (m *Mount) PolicyDir() string {
 	return filepath.Join(m.BaseDir(), policyDirName)
 }
 
-// policyPath returns the full path to a regular policy file with the
+// PolicyPath returns the full path to a regular policy file with the
 // specified descriptor.
-func (m *Mount) policyPath(descriptor string) string {
+func (m *Mount) PolicyPath(descriptor string) string {
 	return filepath.Join(m.PolicyDir(), descriptor)
 }
 
@@ -512,7 +512,7 @@ func (m *Mount) AddPolicy(data *metadata.PolicyData) error {
 		return err
 	}
 
-	return m.err(m.addMetadata(m.policyPath(data.KeyDescriptor), data))
+	return m.err(m.addMetadata(m.PolicyPath(data.KeyDescriptor), data))
 }
 
 // GetPolicy looks up the policy metadata by descriptor.
@@ -521,7 +521,7 @@ func (m *Mount) GetPolicy(descriptor string) (*metadata.PolicyData, error) {
 		return nil, err
 	}
 	data := new(metadata.PolicyData)
-	return data, m.err(m.getMetadata(m.policyPath(descriptor), data))
+	return data, m.err(m.getMetadata(m.PolicyPath(descriptor), data))
 }
 
 // RemovePolicy deletes the policy metadata from the filesystem storage.
@@ -529,7 +529,7 @@ func (m *Mount) RemovePolicy(descriptor string) error {
 	if err := m.CheckSetup(); err != nil {
 		return err
 	}
-	return m.err(m.removeMetadata(m.policyPath(descriptor)))
+	return m.err(m.removeMetadata(m.PolicyPath(descriptor)))
 }
 
 // ListPolicies lists the descriptors of all policies on this filesystem.

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"github.com/google/fscrypt/crypto"
 	"github.com/google/fscrypt/metadata"
@@ -367,7 +366,7 @@ func TestLinkedProtector(t *testing.T) {
 
 	// Get the protector though the second system
 	_, err = fakeMnt.GetRegularProtector(protector.ProtectorDescriptor)
-	if errors.Cause(err) != ErrNoMetadata {
+	if _, ok := err.(*ErrProtectorNotFound); !ok {
 		t.Fatal(err)
 	}
 

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -43,15 +43,9 @@ import (
 
 // Keyring error values
 var (
-	ErrKeyAdd                = util.SystemError("could not add key to the keyring")
-	ErrKeyRemove             = util.SystemError("could not remove key from the keyring")
-	ErrKeyNotPresent         = errors.New("key not present or already removed")
-	ErrKeyFilesOpen          = errors.New("some files using the key are still open")
 	ErrKeyAddedByOtherUsers  = errors.New("other users have added the key too")
-	ErrKeySearch             = errors.New("could not find key with descriptor")
-	ErrSessionUserKeying     = errors.New("user keyring not linked into session keyring")
-	ErrAccessUserKeyring     = errors.New("could not access user keyring")
-	ErrLinkUserKeyring       = util.SystemError("could not link user keyring into root keyring")
+	ErrKeyFilesOpen          = errors.New("some files using the key are still open")
+	ErrKeyNotPresent         = errors.New("key not present or already removed")
 	ErrV2PoliciesUnsupported = errors.New("kernel is too old to support v2 encryption policies")
 )
 


### PR DESCRIPTION
Lots of improvements to `fscrypt` error handling, e.g. using custom error types that allow us to pass more information up to the CLI tool to give better suggestions.  Also fix lots of cases where errors were being wrapped "backwards".  See the individual commits for details.

This pull request is on top of https://github.com/google/fscrypt/pull/217 and https://github.com/google/fscrypt/pull/218.