### PR TITLE
Fix build on Raspbian

### DIFF
--- a/keyring/fs_keyring.go
+++ b/keyring/fs_keyring.go
@@ -228,7 +228,7 @@ func fsRemoveEncryptionKey(descriptor string, mount *filesystem.Mount,
 		return err
 	}
 
-	ioc := unix.FS_IOC_REMOVE_ENCRYPTION_KEY
+	ioc := uintptr(unix.FS_IOC_REMOVE_ENCRYPTION_KEY)
 	iocName := "FS_IOC_REMOVE_ENCRYPTION_KEY"
 	var savedPrivs *savedPrivs
 	if user == nil {


### PR DESCRIPTION
Currently, trying to build on Raspbian fails with the following error:

```
$ go get github.com/google/fscrypt/cmd/fscrypt
# github.com/google/fscrypt/keyring
go/src/github.com/google/fscrypt/keyring/fs_keyring.go:231:6: constant 3225445912 overflows int
go/src/github.com/google/fscrypt/keyring/fs_keyring.go:235:7: constant 3225445913 overflows int
```