### PR TITLE
travis.yml: stop overriding e2fsprogs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,12 +46,7 @@ jobs:
 
     - name: Integration Tests
       sudo: required
-      addons:
-        apt:
-          sources:
-            - sourceline: 'deb http://en.archive.ubuntu.com/ubuntu/ artful main universe'
-          packages:
-            - e2fsprogs
+      before_install: sudo apt-get -y install e2fsprogs
       install:
         - go get -u github.com/mattn/goveralls
         - make test-setup


### PR DESCRIPTION
There's no longer a need to override the Ubuntu version that the
Travis CI builds install e2fsprogs from, since we now use
"dist: bionic", and e2fsprogs in Bionic supports encryption.