### PR TITLE
cmd/fscrypt: fix up path formatting in ErrDirNotEmpty suggestion

### DIFF
--- a/cli-tests/t_encrypt.out
+++ b/cli-tests/t_encrypt.out
@@ -13,12 +13,34 @@ ext4 filesystem "MNT" has 0 protectors and 0 policies
 Files cannot be encrypted in-place. Instead, encrypt a new directory, copy the
 files into it, and securely delete the original directory. For example:
 
-     mkdir MNT/dir.new
-     fscrypt encrypt MNT/dir.new
-     cp -a -T MNT/dir MNT/dir.new
-     find MNT/dir -type f -print0 | xargs -0 shred -n1 --remove=unlink
-     rm -rf MNT/dir
-     mv MNT/dir.new MNT/dir
+     mkdir "MNT/dir.new"
+     fscrypt encrypt "MNT/dir.new"
+     cp -a -T "MNT/dir" "MNT/dir.new"
+     find "MNT/dir" -type f -print0 | xargs -0 shred -n1 --remove=unlink
+     rm -rf "MNT/dir"
+     mv "MNT/dir.new" "MNT/dir"
+
+Caution: due to the nature of modern storage devices and filesystems, the
+original data may still be recoverable from disk. It's much better to encrypt
+your files from the start.
+ext4 filesystem "MNT" has 0 protectors and 0 policies
+
+[ERROR] fscrypt status: file or directory "MNT/dir" is not
+                        encrypted
+
+# => with trailing slash
+[ERROR] fscrypt encrypt: Directory "MNT/dir/" cannot be
+                         encrypted because it is non-empty.
+
+Files cannot be encrypted in-place. Instead, encrypt a new directory, copy the
+files into it, and securely delete the original directory. For example:
+
+     mkdir "MNT/dir.new"
+     fscrypt encrypt "MNT/dir.new"
+     cp -a -T "MNT/dir" "MNT/dir.new"
+     find "MNT/dir" -type f -print0 | xargs -0 shred -n1 --remove=unlink
+     rm -rf "MNT/dir"
+     mv "MNT/dir.new" "MNT/dir"
 
 Caution: due to the nature of modern storage devices and filesystems, the
 original data may still be recoverable from disk. It's much better to encrypt

--- a/cli-tests/t_encrypt.sh
+++ b/cli-tests/t_encrypt.sh
@@ -35,6 +35,9 @@ begin "Try to encrypt a nonempty directory"
 touch "$dir/file"
 _expect_failure "echo hunter2 | fscrypt encrypt --quiet '$dir'"
 show_status false
+_print_header "=> with trailing slash"
+_expect_failure "echo hunter2 | fscrypt encrypt --quiet '$dir/'"
+show_status false
 
 begin "Encrypt a directory as non-root user"
 chown "$TEST_USER" "$dir"

--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -179,18 +179,18 @@ func getErrorSuggestions(err error) string {
 
 		> fscrypt lock %q`, e.DirPath, e.DirPath)
 	case *ErrDirNotEmpty:
-		dir := e.DirPath
+		dir := filepath.Clean(e.DirPath)
 		newDir := dir + ".new"
 		return fmt.Sprintf(`Files cannot be encrypted in-place. Instead,
 		encrypt a new directory, copy the files into it, and securely
 		delete the original directory. For example:
 
-		> mkdir %s
-		> fscrypt encrypt %s
-		> cp -a -T %s %s
-		> find %s -type f -print0 | xargs -0 shred -n1 --remove=unlink
-		> rm -rf %s
-		> mv %s %s
+		> mkdir %q
+		> fscrypt encrypt %q
+		> cp -a -T %q %q
+		> find %q -type f -print0 | xargs -0 shred -n1 --remove=unlink
+		> rm -rf %q
+		> mv %q %q
 
 		Caution: due to the nature of modern storage devices and filesystems,
 		the original data may still be recoverable from disk. It's much better


### PR DESCRIPTION
Use %q, in case the paths contain whitespace.  Also clean the directory
path to remove trailing slashes before appending the ".new" suffix.