### PR TITLE
cmd/fscrypt: fix 32-bit build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,13 @@ jobs:
     - <<: *build
       go: 1.11.x
 
+    - name: Build and Unit Tests (32-bit)
+      before_install:
+        - sudo apt-get -y install gcc-multilib libpam0g-dev:i386
+      script:
+        - GO111MODULE=on go get github.com/google/fscrypt/cmd/fscrypt
+        - CGO_ENABLED=1 GOARCH=386 make
+
     - name: Integration Tests
       sudo: required
       before_install: sudo apt-get -y install e2fsprogs

--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -117,8 +117,8 @@ func suggestEnablingEncryption(mnt *filesystem.Mount) string {
 		if err := unix.Statfs(mnt.Path, &statfs); err != nil {
 			return ""
 		}
-		pagesize := int64(os.Getpagesize())
-		if statfs.Bsize != pagesize && !util.IsKernelVersionAtLeast(5, 5) {
+		pagesize := os.Getpagesize()
+		if int64(statfs.Bsize) != int64(pagesize) && !util.IsKernelVersionAtLeast(5, 5) {
 			return fmt.Sprintf(`This filesystem uses a block size
 			(%d) other than the system page size (%d). Ext4
 			encryption didn't support this case until kernel v5.5.


### PR DESCRIPTION
statfs.Bsize actually has platform-dependent type, despite the Go
documentation listing it as int64.

Resolves https://github.com/google/fscrypt/issues/233