### PR TITLE
travis.yml: upgrade to Ubuntu 20.04 and enable cli tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 sudo: false
-dist: bionic
+dist: focal
 arch:
   - amd64
   - ppc64le
@@ -65,6 +65,14 @@ jobs:
       script:
         - make coverage.out
         - goveralls -coverprofile=coverage.out -service=travis-ci
+
+    - name: Command-line interface tests
+      sudo: required
+      before_install:
+        - sudo apt-get -y install e2fsprogs expect keyutils
+      script:
+        - GO111MODULE=on go get github.com/google/fscrypt/cmd/fscrypt
+        - make cli-test
 
     - stage: deploy
       name: Release Binaries

--- a/cli-tests/common.sh
+++ b/cli-tests/common.sh
@@ -117,7 +117,7 @@ _user_do()
 {
 	[ $# -ne 1 ] && _fail "wrong argument count to ${FUNCNAME[0]}"
 
-	su "$TEST_USER" --command="$1"
+	su "$TEST_USER" --shell=/bin/bash --command="export PATH='$PATH'; $1"
 }
 
 # Runs the given shell command as the test user and expects it to fail.

--- a/cmd/fscrypt/keys.go
+++ b/cmd/fscrypt/keys.go
@@ -86,9 +86,6 @@ func (p passphraseReader) Read(buf []byte) (int, error) {
 // passphrase into a key. If we are not reading from a terminal, just read into
 // the passphrase into the key normally.
 func getPassphraseKey(prompt string) (*crypto.Key, error) {
-	if !quietFlag.Value {
-		fmt.Print(prompt)
-	}
 
 	// Only disable echo if stdin is actually a terminal.
 	if terminal.IsTerminal(stdinFd) {
@@ -100,6 +97,10 @@ func getPassphraseKey(prompt string) (*crypto.Key, error) {
 			terminal.Restore(stdinFd, state)
 			fmt.Println() // To align input
 		}()
+	}
+
+	if !quietFlag.Value {
+		fmt.Print(prompt)
 	}
 
 	return crypto.NewKeyFromReader(passphraseReader{})


### PR DESCRIPTION
Now that Travis CI supports a version of Ubuntu that has a kernel that
supports v2 encryption policies, upgrade to it and enable the cli tests.