### PR TITLE
read raw key from stdin if --key isn't specified

### DIFF
--- a/ThreatDragonModels/Test/Test.json
+++ b/ThreatDragonModels/Test/Test.json
@@ -1,0 +1,17 @@
+{
+  "summary": {
+    "owner": "Test",
+    "title": "Test"
+  },
+  "detail": {
+    "contributors": [],
+    "diagrams": [
+      {
+        "title": "Test",
+        "thumbnail": "./public/content/images/thumbnail.jpg",
+        "id": 0
+      }
+    ],
+    "reviewer": ""
+  }
+}


### PR DESCRIPTION
Hello everyone,

This pull request contains some additions to fscrypt so you can now pass base64 encoded raw key and use it without the need to create the raw key file on the file system and worry about its security.

Best