### PR TITLE
cmd/fscrypt: fix missing protector error format

### DIFF
--- a/cmd/fscrypt/prompt.go
+++ b/cmd/fscrypt/prompt.go
@@ -282,7 +282,8 @@ func promptForProtector(options []*actions.ProtectorOption) (int, error) {
 	}
 
 	if numLoadErrors > 0 {
-		fmt.Print(wrapText("NOTE: %d of the %d protectors failed to load. "+loadHelpText, 0))
+		loadWarning := fmt.Sprintf("NOTE: %d of the %d protectors failed to load. ", numLoadErrors, numOptions)
+		fmt.Print(wrapText(loadWarning+loadHelpText, 0) + "\n")
 	}
 
 	for {


### PR DESCRIPTION
This is the bugette mentioned in #272 - the format specifiers were never being filled in.
Also add a newline so the prompt to select a protector shows on a separate line.