### PR TITLE
pam_fscrypt/config: prioritise over other session modules

### DIFF
--- a/pam_fscrypt/config
+++ b/pam_fscrypt/config
@@ -1,6 +1,6 @@
 Name: fscrypt PAM passphrase support
 Default: yes
-Priority: 0
+Priority: 100
 Auth-Type: Additional
 Auth-Final:
 	optional	PAM_INSTALL_PATH


### PR DESCRIPTION
Services launched by systemd user sessions on Debian / Ubuntu systems are often not able to access the home directory, because there is no guarantee / requirement that pam_fscrypt is sequenced before pam_systemd. Although this pam-config mechanism is Debian-specific, the config file is provided here upstream and unmodified in Debian. Raising the priority here so that it's always ordered ahead of pam_systemd will solve issues such as https://github.com/google/fscrypt/issues/270, https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=964951 and https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1889416.