### PR TITLE
cmd/fscrypt: use golang.org/x/term

### DIFF
--- a/cmd/fscrypt/format.go
+++ b/cmd/fscrypt/format.go
@@ -29,7 +29,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/urfave/cli"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	"github.com/google/fscrypt/util"
 )
@@ -64,7 +64,7 @@ func init() {
 	flagPaddingLength = maxShortDisplay + 2*indentLength
 
 	// We use the width of the terminal unless we cannot get the width.
-	width, _, err := terminal.GetSize(int(os.Stdout.Fd()))
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
 		lineLength = fallbackLineLength
 	} else {

--- a/cmd/fscrypt/keys.go
+++ b/cmd/fscrypt/keys.go
@@ -28,7 +28,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	"github.com/google/fscrypt/actions"
 	"github.com/google/fscrypt/crypto"
@@ -88,13 +88,13 @@ func (p passphraseReader) Read(buf []byte) (int, error) {
 func getPassphraseKey(prompt string) (*crypto.Key, error) {
 
 	// Only disable echo if stdin is actually a terminal.
-	if terminal.IsTerminal(stdinFd) {
-		state, err := terminal.MakeRaw(stdinFd)
+	if term.IsTerminal(stdinFd) {
+		state, err := term.MakeRaw(stdinFd)
 		if err != nil {
 			return nil, err
 		}
 		defer func() {
-			terminal.Restore(stdinFd, state)
+			term.Restore(stdinFd, state)
 			fmt.Println() // To align input
 		}()
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,8 @@ require (
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
 	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529
 	golang.org/x/lint v0.0.0-20190930215403-16217165b5de
-	golang.org/x/sys v0.0.0-20191127021746-63cb32ae39b2
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
+	golang.org/x/term v0.0.0-20210422114643-f5beecf764ed
 	golang.org/x/tools v0.0.0-20191025023517-2077df36852e
 	honnef.co/go/tools v0.0.1-2019.2.3
 )

--- a/go.sum
+++ b/go.sum
@@ -28,10 +28,11 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191127021746-63cb32ae39b2 h1:/J2nHFg1MTqaRLFO7M+J78ASNsJoz3r0cvHBPQ77fsE=
-golang.org/x/sys v0.0.0-20191127021746-63cb32ae39b2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20210422114643-f5beecf764ed h1:Ei4bQjjpYUsS4efOUz+5Nz++IVkHk87n2zBA0NxBWc0=
+golang.org/x/term v0.0.0-20210422114643-f5beecf764ed/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=


### PR DESCRIPTION
The `golang.org/x/crypto/ssh/terminal` package is deprecated and merely a
wrapper around `golang.org/x/term`. Thus, use the latter directly.