### PR TITLE
Specify -buildmode=c-shared after GO_FLAGS rather than before

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ $(BIN)/$(NAME): $(GO_FILES) $(C_FILES)
 	go build $(GO_FLAGS) -o $@ ./cmd/$(NAME)
 
 $(PAM_MODULE): $(GO_FILES) $(C_FILES)
-	go build -buildmode=c-shared $(GO_FLAGS) -o $@ ./$(PAM_NAME)
+	go build $(GO_FLAGS) -buildmode=c-shared -o $@ ./$(PAM_NAME)
 	rm -f $(BIN)/$(PAM_NAME).h
 
 gen: $(BIN)/protoc $(BIN)/protoc-gen-go $(PROTO_FILES)


### PR DESCRIPTION
When building pam_fscrypt.so, specify -buildmode=c-shared after
$(GO_FLAGS) so that it overrides any user-specified buildmode.

This is needed to allow -buildmode=pie to be specified in GO_FLAGS if
the packager wants to build fscrypt as a position-independent executable
(e.g. following https://wiki.archlinux.org/title/Go_package_guidelines).
Previously, trying to do this caused pam_fscrypt.so to be incorrectly
built as an executable rather than as a shared library.