### PR TITLE
Only use 1/8 of the system RAM and run the Garbage Collector in the timing loop

### DIFF
--- a/actions/config.go
+++ b/actions/config.go
@@ -276,6 +276,9 @@ func timeHashingCosts(costs *metadata.HashingCosts) (time.Duration, error) {
 	}
 	end := cpuTimeInNanoseconds()
 
+	// This uses a lot of memory, run the garbage collector
+	runtime.GC()
+
 	return time.Duration((end - begin) / costs.Parallelism), nil
 }
 

--- a/actions/config.go
+++ b/actions/config.go
@@ -242,7 +242,7 @@ func getHashingCosts(target time.Duration) (*metadata.HashingCosts, error) {
 
 // memoryBytesLimit returns the maximum amount of memory we will use for
 // passphrase hashing. This will never be more than a reasonable maximum (for
-// compatibility) or half the available system RAM.
+// compatibility) or an 8th the available system RAM.
 func memoryBytesLimit() int64 {
 	// The sysinfo syscall only fails if given a bad address
 	var info unix.Sysinfo_t
@@ -250,7 +250,7 @@ func memoryBytesLimit() int64 {
 	util.NeverError(err)
 
 	totalRAMBytes := int64(info.Totalram)
-	return util.MinInt64(totalRAMBytes/2, maxMemoryBytes)
+	return util.MinInt64(totalRAMBytes/8, maxMemoryBytes)
 }
 
 // betweenCosts returns a cost between a and b. Specifically, it returns the


### PR DESCRIPTION
Running `crypto.PassphraseHash` in a loop allocates a lot of memory.
Golang is not always prudent about collecting the garbage from previous
runs, resulting in a OOM error on memory-pressured systems.

With a `maxMemoryBytes` of 128 MiB, this change reduces the maximum
resident memory for `fscrypt setup` to 141 MiB (was perviously 405 MiB)

Fixes #291