### PR TITLE
cmd/fscrypt: recognize no-key names containing hyphen

### DIFF
--- a/cmd/fscrypt/commands.go
+++ b/cmd/fscrypt/commands.go
@@ -539,8 +539,10 @@ func isPossibleNoKeyName(filename string) bool {
 	if len(filename) < 22 {
 		return false
 	}
-	// No-key names contain only base64 characters and underscore.
-	validChars := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+,_"
+	// On the latest kernels, no-key names contain only base64url characters
+	// (A-Z, a-z, 0-9, -, and _).  On older kernels, the + and , characters
+	// were used too.  Allow all of these characters.
+	validChars := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_+,"
 	for _, char := range filename {
 		if !strings.ContainsRune(validChars, char) {
 			return false


### PR DESCRIPTION
In Linux 5.15, the no-key name format is changing again; see
https://git.kernel.org/linus/ba47b515f5940603.  isPossibleNoKeyName()
sometimes doesn't recognize the new no-key names.  Update it accordingly
to recognize all possible no-key names.

Note: isPossibleNoKeyName() is only used as a heuristic to check whether
a v1-encrypted directory is incompletely locked or not.  Therefore, it's
not too important whether it works.  However, this change is needed for
cli-tests/t_v1_policy to pass.