### PR TITLE
Adjust recovery passphrase generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,14 +474,19 @@ via a login protector if the operating system is reinstalled or if the disk is
 connected to another system** -- even if the new system uses the same login
 passphrase for the user.
 
-Because of this, `fscrypt encrypt` will offer to generate a recovery passphrase
-when creating a login passphrase-protected directory on a non-root filesystem.
-The recovery passphrase is simply a `custom_passphrase` protector with a
-randomly generated high-entropy passphrase.  It is strongly recommended to
-accept the prompt to generate the recovery passphrase, then store the recovery
-passphrase in a secure location.  Then, if ever needed, you can use `fscrypt
-unlock` to unlock the directory with the recovery passphrase (by choosing the
-recovery protector instead of the login protector).
+Because of this, `fscrypt encrypt` will automatically generate a recovery
+passphrase when creating a login passphrase-protected directory on a non-root
+filesystem.  The recovery passphrase is simply a `custom_passphrase` protector
+with a randomly generated high-entropy passphrase.  Initially, the recovery
+passphrase is stored in a file in the encrypted directory itself; therefore, to
+use it you **must** record it in another secure location.  It is strongly
+recommended to do this.  Then, if ever needed, you can use `fscrypt unlock` to
+unlock the directory with the recovery passphrase (by choosing the recovery
+protector instead of the login protector).
+
+If you really want to disable the generation of a recovery passphrase, use the
+`--no-recovery` option.  Only do this if you really know what you are doing and
+are prepared for potential data loss.
 
 Alternative approaches to supporting recovery of login passphrase-protected
 directories include the following:
@@ -493,7 +498,7 @@ directories include the following:
   Note that after restoring the `/.fscrypt` directory, unlocking the login
   protectors will require the passphrases they had at the time the backup was
   made **even if they were changed later**, so make sure to remember these
-  passphrase(s) or store them in a secure location.  Also note that if the UUID
+  passphrase(s) or record them in a secure location.  Also note that if the UUID
   of the root filesystem changed, you will need to manually fix the UUID in any
   `.fscrypt/protectors/*.link` files on other filesystems.
 

--- a/actions/recovery_test.go
+++ b/actions/recovery_test.go
@@ -67,7 +67,8 @@ func TestRecoveryPassphrase(t *testing.T) {
 	}
 
 	// Test writing the recovery instructions.
-	if err = WriteRecoveryInstructions(passphrase, recoveryFile); err != nil {
+	if err = WriteRecoveryInstructions(passphrase, recoveryProtector, policy,
+		recoveryFile); err != nil {
 		t.Fatal(err)
 	}
 	contentsBytes, err := ioutil.ReadFile(recoveryFile)

--- a/cli-tests/t_encrypt_login.out
+++ b/cli-tests/t_encrypt_login.out
@@ -1,6 +1,12 @@
 
 # Encrypt with login protector
-See "MNT/dir/fscrypt_recovery_readme.txt" for important recovery instructions!
+
+IMPORTANT: See "MNT/dir/fscrypt_recovery_readme.txt" for
+           important recovery instructions. It is *strongly recommended* to
+           record the recovery passphrase in a secure location; otherwise you
+           will lose access to this directory if you reinstall the operating
+           system or move this filesystem to another system.
+
 ext4 filesystem "MNT" has 2 protectors and 1 policy
 
 PROTECTOR         LINKED                              DESCRIPTION
@@ -43,8 +49,13 @@ IMPORTANT: Before continuing, ensure you have properly set up your system for
            https://github.com/google/fscrypt#setting-up-for-login-protectors
 
 Enter login passphrase for fscrypt-test-user: 
-Protector is on a different filesystem! Generate a recovery passphrase (recommended)? [Y/n] y
-See "MNT/dir/fscrypt_recovery_readme.txt" for important recovery instructions!
+
+IMPORTANT: See "MNT/dir/fscrypt_recovery_readme.txt" for
+           important recovery instructions. It is *strongly recommended* to
+           record the recovery passphrase in a secure location; otherwise you
+           will lose access to this directory if you reinstall the operating
+           system or move this filesystem to another system.
+
 "MNT/dir" is now encrypted, unlocked, and ready for use.
 ext4 filesystem "MNT" has 2 protectors and 1 policy
 
@@ -70,7 +81,13 @@ desc10  Yes (MNT_ROOT)  login protector for fscrypt-test-user
 desc11  No                                  custom protector "Recovery passphrase for dir"
 
 # Encrypt with login protector as root
-See "MNT/dir/fscrypt_recovery_readme.txt" for important recovery instructions!
+
+IMPORTANT: See "MNT/dir/fscrypt_recovery_readme.txt" for
+           important recovery instructions. It is *strongly recommended* to
+           record the recovery passphrase in a secure location; otherwise you
+           will lose access to this directory if you reinstall the operating
+           system or move this filesystem to another system.
+
 ext4 filesystem "MNT" has 2 protectors and 1 policy
 
 PROTECTOR         LINKED                              DESCRIPTION

--- a/cli-tests/t_encrypt_login.sh
+++ b/cli-tests/t_encrypt_login.sh
@@ -50,8 +50,6 @@ expect "Enter the source number for the new protector"
 send "1\r"
 expect "Enter login passphrase"
 send "TEST_USER_PASS\r"
-expect "Protector is on a different filesystem! Generate a recovery passphrase (recommended)?"
-send "y\r"
 expect eof
 EOF
 show_status true

--- a/cmd/fscrypt/flags.go
+++ b/cmd/fscrypt/flags.go
@@ -174,7 +174,7 @@ var (
 	}
 	noRecoveryFlag = &boolFlag{
 		Name:  "no-recovery",
-		Usage: `Don't ask to generate a recovery passphrase.`,
+		Usage: `Don't generate a recovery passphrase.`,
 	}
 )
 

--- a/cmd/fscrypt/format.go
+++ b/cmd/fscrypt/format.go
@@ -65,7 +65,7 @@ func init() {
 
 	// We use the width of the terminal unless we cannot get the width.
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
+	if err != nil || width <= 0 {
 		lineLength = fallbackLineLength
 	} else {
 		lineLength = util.MinInt(width, maxLineLength)


### PR DESCRIPTION
As per the feedback at https://github.com/google/fscrypt/issues/115
where users didn't understand that the recovery passphrase is important,
restore the original behavior where recovery passphrase generation
happens automatically without a prompt.  This applies to the case where
'fscrypt encrypt' is using a login protector on a non-root filesystem.

However, leave the --no-recovery option so that the recovery passphrase
can still be disabled if the user really wants to.  Also, clarify the
information provided about the recovery passphrase.

Update https://github.com/google/fscrypt/issues/115