### PR TITLE
Set owner of login protectors to correct user

### DIFF
--- a/cli-tests/t_encrypt_login.out
+++ b/cli-tests/t_encrypt_login.out
@@ -111,6 +111,8 @@ PROTECTOR         LINKED                              DESCRIPTION
 desc19  Yes (MNT_ROOT)  login protector for fscrypt-test-user
 desc20  No                                  custom protector "Recovery passphrase for dir"
 
+Protector is owned by fscrypt-test-user:fscrypt-test-user
+
 # Encrypt with login protector with --no-recovery
 ext4 filesystem "MNT" has 1 protector and 1 policy
 

--- a/cli-tests/t_encrypt_login.sh
+++ b/cli-tests/t_encrypt_login.sh
@@ -27,13 +27,18 @@ show_status()
 	fi
 }
 
+get_login_protector()
+{
+	fscrypt status "$dir" | awk '/login protector/{print $1}'
+}
+
 begin "Encrypt with login protector"
 chown "$TEST_USER" "$dir"
 _user_do "echo TEST_USER_PASS | fscrypt encrypt --quiet --source=pam_passphrase '$dir'"
 show_status true
 recovery_passphrase=$(grep -E '^ +[a-z]{20}$' "$dir/fscrypt_recovery_readme.txt" | sed 's/^ +//')
 recovery_protector=$(fscrypt status "$dir" | awk '/Recovery passphrase/{print $1}')
-login_protector=$(fscrypt status "$dir" | awk '/login protector/{print $1}')
+login_protector=$(get_login_protector)
 _print_header "=> Lock, then unlock with login passphrase"
 _user_do "fscrypt lock '$dir'"
 # FIXME: should we be able to use $MNT:$login_protector here?
@@ -57,6 +62,10 @@ show_status true
 begin "Encrypt with login protector as root"
 echo TEST_USER_PASS | fscrypt encrypt --quiet --source=pam_passphrase --user="$TEST_USER" "$dir"
 show_status true
+# The newly-created login protector should be owned by the user, not root.
+login_protector=$(get_login_protector)
+owner=$(stat -c "%U:%G" "$MNT_ROOT/.fscrypt/protectors/$login_protector")
+echo -e "\nProtector is owned by $owner"
 
 begin "Encrypt with login protector with --no-recovery"
 chown "$TEST_USER" "$dir"

--- a/util/util.go
+++ b/util/util.go
@@ -121,14 +121,26 @@ func AtoiOrPanic(input string) int {
 	return i
 }
 
+// UserFromUID returns the User corresponding to the given user id.
+func UserFromUID(uid int64) (*user.User, error) {
+	return user.LookupId(strconv.FormatInt(uid, 10))
+}
+
 // EffectiveUser returns the user entry corresponding to the effective user.
 func EffectiveUser() (*user.User, error) {
-	return user.LookupId(strconv.Itoa(os.Geteuid()))
+	return UserFromUID(int64(os.Geteuid()))
 }
 
 // IsUserRoot checks if the effective user is root.
 func IsUserRoot() bool {
 	return os.Geteuid() == 0
+}
+
+// Chown changes the owner of a File to a User.
+func Chown(file *os.File, user *user.User) error {
+	uid := AtoiOrPanic(user.Uid)
+	gid := AtoiOrPanic(user.Gid)
+	return file.Chown(uid, gid)
 }
 
 // IsKernelVersionAtLeast returns true if the Linux kernel version is at least


### PR DESCRIPTION
When the root user creates a login protector for a non-root user, make
sure to chown() the protector file to make it owned by the user.
Without this, the protector cannot be updated by the user, which causes
it to get out of sync if the user changes their login passphrase.

Fixes https://github.com/google/fscrypt/issues/319