### PR TITLE
filesystem: avoid accessing irrelevant filesystems

### DIFF
--- a/cli-tests/t_not_supported.out
+++ b/cli-tests/t_not_supported.out
@@ -1,8 +1,8 @@
 
 # Mount tmpfs
 
-# Create fscrypt metadata on tmpfs
-Metadata directories created at "MNT/.fscrypt".
+# Try to create fscrypt metadata on tmpfs
+[ERROR] fscrypt setup: filesystem type tmpfs is not supported for fscrypt setup
 
 # Try to encrypt a directory on tmpfs
 [ERROR] fscrypt encrypt: This kernel doesn't support encryption on tmpfs

--- a/cli-tests/t_not_supported.sh
+++ b/cli-tests/t_not_supported.sh
@@ -9,8 +9,8 @@ _print_header "Mount tmpfs"
 umount "$MNT"
 mount tmpfs -t tmpfs -o size=128m "$MNT"
 
-_print_header "Create fscrypt metadata on tmpfs"
-fscrypt setup "$MNT"
+_print_header "Try to create fscrypt metadata on tmpfs"
+_expect_failure "fscrypt setup '$MNT'"
 
 _print_header "Try to encrypt a directory on tmpfs"
 mkdir "$MNT/dir"

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -324,7 +324,7 @@ func getTwoSetupMounts(t *testing.T) (realMnt, fakeMnt *Mount, err error) {
 	if err = os.MkdirAll(fakeMountpoint, basePermissions); err != nil {
 		return
 	}
-	fakeMnt = &Mount{Path: fakeMountpoint}
+	fakeMnt = &Mount{Path: fakeMountpoint, FilesystemType: realMnt.FilesystemType}
 	err = fakeMnt.Setup()
 	return
 }


### PR DESCRIPTION
Forbid 'fscrypt setup' on filesystems that aren't expected to support
encryption (other than the root filesystem), and skip looking for
fscrypt metadata directories on such filesystems.  This has two
benefits.  First, it avoids the printing of annoying warnings like:

        pam_fscrypt[75038]: stat /run/user/0/.fscrypt: permission denied
        pam_fscrypt[75038]: stat /run/user/0/.fscrypt/policies: permission denied
        pam_fscrypt[75038]: stat /run/user/0/.fscrypt/protectors: permission denied
        pam_fscrypt[75038]: stat /sys/firmware/efi/efivars/.fscrypt: invalid argument
        pam_fscrypt[75038]: stat /sys/firmware/efi/efivars/.fscrypt/policies: invalid argument
        pam_fscrypt[75038]: stat /sys/firmware/efi/efivars/.fscrypt/protectors: invalid argument
        pam_fscrypt[75038]: stat /sys/fs/pstore/.fscrypt: permission denied
        pam_fscrypt[75038]: stat /sys/fs/pstore/.fscrypt/policies: permission denied
        pam_fscrypt[75038]: stat /sys/fs/pstore/.fscrypt/protectors: permission denied

Second, it avoids long delays or side effects on some filesystems.

To do this, introduce an allowlist of filesystem types that fscrypt will
recognize.  I wanted to avoid doing this, since this list will need to
be updated in the future, but I don't see a better solution.
