### PR TITLE
pam_fscrypt: warn user if OLDAUTHTOK not given in chauthtok

### DIFF
--- a/pam/pam.c
+++ b/pam/pam.c
@@ -20,6 +20,7 @@
 #include "pam.h"
 
 #include <security/pam_appl.h>
+#include <security/pam_ext.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -106,4 +107,8 @@ void freeSecret(pam_handle_t* pamh, char* data, int error_status) {
   memset_sec(data, 0, size);
   munlock(data, size);
   free(data);
+}
+
+void infoMessage(pam_handle_t* pamh, const char* message) {
+  pam_info(pamh, "%s", message);
 }

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -166,6 +166,13 @@ func (h *Handle) err() error {
 	return errors.New(s)
 }
 
+// InfoMessage sends a message to the application using pam_info().
+func (h *Handle) InfoMessage(message string) {
+	cMessage := C.CString(message)
+	defer C.free(unsafe.Pointer(cMessage))
+	C.infoMessage(h.handle, cMessage)
+}
+
 // Transaction represents a wrapped pam_handle_t type created with pam_start
 // form an application.
 type Transaction Handle

--- a/pam/pam.h
+++ b/pam/pam.h
@@ -41,4 +41,7 @@ void *copyIntoSecret(void *data);
 // CleaupFunc that Zeros wipes a C string and unlocks and frees its memory.
 void freeSecret(pam_handle_t *pamh, char *data, int error_status);
 
+// Sends a message to the application using pam_info().
+void infoMessage(pam_handle_t *pamh, const char *message);
+
 #endif  // FSCRYPT_PAM_H


### PR DESCRIPTION
If someone runs 'passwd USER' as root, the user is assigned a new login
passphrase without their fscrypt login protector being updated.  Detect
this case and show a warning message using pam_info().

Fixes https://github.com/google/fscrypt/issues/273