### PR TITLE
context_text: remove pre-existing test.conf

### DIFF
--- a/actions/context_test.go
+++ b/actions/context_test.go
@@ -47,6 +47,7 @@ func setupContext() (ctx *Context, err error) {
 	ConfigFileLocation = filepath.Join(mountpoint, "test.conf")
 
 	// Should not be able to setup without a config file
+	os.Remove(ConfigFileLocation)
 	if badCtx, badCtxErr := NewContextFromMountpoint(mountpoint, nil); badCtxErr == nil {
 		badCtx.Mount.RemoveAllMetadata()
 		return nil, fmt.Errorf("created context at %q without config file", badCtx.Mount.Path)


### PR DESCRIPTION
This fixes a test failure in the case where test.conf gets left over.