### PR TITLE
filesystem: store mountpoint in link files as a fallback

### DIFF
--- a/cli-tests/t_encrypt_login.out
+++ b/cli-tests/t_encrypt_login.out
@@ -174,3 +174,20 @@ ext4 filesystem "MNT_ROOT" has 0 protectors and 0 policies
 
 [ERROR] fscrypt status: file or directory "MNT/dir" is not
                         encrypted
+
+# Test that linked protector works even if UUID link is broken
+
+IMPORTANT: See "MNT/dir/fscrypt_recovery_readme.txt" for
+           important recovery instructions. It is *strongly recommended* to
+           record the recovery passphrase in a secure location; otherwise you
+           will lose access to this directory if you reinstall the operating
+           system or move this filesystem to another system.
+
+ext4 filesystem "MNT" has 2 protectors and 1 policy
+
+PROTECTOR         LINKED                              DESCRIPTION
+desc39  No                                  custom protector "Recovery passphrase for dir"
+desc40  Yes (MNT_ROOT)  login protector for fscrypt-test-user
+
+POLICY                            UNLOCKED  PROTECTORS
+desc41  Yes       desc40, desc39

--- a/cli-tests/t_encrypt_login.sh
+++ b/cli-tests/t_encrypt_login.sh
@@ -91,3 +91,11 @@ chown "$TEST_USER" "$dir"
 _user_do_and_expect_failure \
 	"echo wrong_passphrase | fscrypt encrypt --quiet --source=pam_passphrase '$dir'"
 show_status false
+
+begin "Test that linked protector works even if UUID link is broken"
+echo TEST_USER_PASS | fscrypt encrypt --quiet --source=pam_passphrase --user="$TEST_USER" "$dir"
+protector=$(get_login_protector)
+link_file=$MNT/.fscrypt/protectors/$protector.link
+[ -e "$link_file" ] || _fail "$link_file does not exist"
+sed -i 's/UUID=.*/UUID=00000000-0000-0000-0000-000000000000/' "$link_file"
+fscrypt status "$MNT"

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -176,8 +176,7 @@ var SortDescriptorsByLastMtime = false
 //
 // There is also the ability to reference another filesystem's metadata. This is
 // used when a Policy on filesystem A is protected with Protector on filesystem
-// B. In this scenario, we store a "link file" in the protectors directory whose
-// contents look like "UUID=3a6d9a76-47f0-4f13-81bf-3332fbe984fb".
+// B. In this scenario, we store a "link file" in the protectors directory.
 //
 // We also allow ".fscrypt" to be a symlink which was previously created. This
 // allows login protectors to be created when the root filesystem is read-only,
@@ -588,7 +587,7 @@ func (m *Mount) AddLinkedProtector(descriptor string, dest *Mount) (bool, error)
 
 	// Right now, we only make links using UUIDs.
 	var newLink string
-	newLink, err = makeLink(dest, "UUID")
+	newLink, err = makeLink(dest)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Currently, linked protectors use filesystem link files of the form
"UUID=\<uuid\>".  These links get broken if the filesystem's UUID changes,
e.g. due to the filesystem being re-created even if the ".fscrypt"
directory is backed up and restored.

To prevent links from being broken (in most cases), start storing the
mountpoint path in the link files too, in the form
"UUID=\<uuid\>\nPATH=\<path\>\n".  When following a link, try the UUID
first, and if it doesn't work try the PATH.  While it's possible that
the path changed too, for login protectors (the usual use case of linked
protectors) this won't be an issue as the path will always be "/".

An alternative solution would be to fall back to scanning all
filesystems for the needed protector descriptor.  I decided not to do
that, since relying on a global scan doesn't seem to be a good design.
It wouldn't scale to large numbers of filesystems, it could cross
security boundaries, and it would make it possible for adding a new
filesystem to break fscrypt on existing filesystems.  And if a global
scan was an acceptable way to find protectors during normal use, then
there would be no need for link files in the first place.

Note: this change is backwards compatible (i.e., fscrypt will continue
to recognize old link files) but not forwards-compatible (i.e., previous
versions of fscrypt won't recognize new link files).

Fixes https://github.com/google/fscrypt/issues/311
