### PR TITLE
filesystem: add 'lustre' to supported filesystem types

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -393,7 +393,7 @@ func (m *Mount) isFscryptSetupAllowed() bool {
 		return true
 	}
 	switch m.FilesystemType {
-	case "ext4", "f2fs", "ubifs", "btrfs", "ceph", "xfs":
+	case "ext4", "f2fs", "ubifs", "btrfs", "ceph", "xfs", "lustre":
 		return true
 	default:
 		return false


### PR DESCRIPTION
Add the Lustre filesystem to the list of supported types.
Lustre fully supports fscrypt API since version 2.15.0:
(ref: https://jira.whamcloud.com/browse/LU-12275
  and https://jira.whamcloud.com/browse/LU-13717).

Fixes: d0b9e2c9 ("filesystem: avoid accessing irrelevant filesystems")
Signed-off-by: Andreas Dilger <adilger@dilger.ca>