### PR TITLE
Bump up required Go version to 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ['1.14', '1.13', '1.12', '1.11']
+        go: ['1.18', '1.17', '1.16']
     name: Build (Go ${{ matrix.go }})
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +40,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libpam0g-dev
     - name: Build
-      run: GO111MODULE=on make
+      run: make
 
   build-32bit:
     name: Build (32-bit)
@@ -97,7 +97,6 @@ jobs:
   #           apt-get install -y build-essential git sudo golang-go \
   #                              libpam0g-dev e2fsprogs keyutils
   #         run: |
-  #           export GO111MODULE=on
   #           make test-setup
   #           keyctl link @u @s
   #           make test

--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,6 @@ VERSION_FLAG := -X "main.version=$(if $(TAG_VERSION),$(TAG_VERSION),$(VERSION))"
 
 override GO_LINK_FLAGS += $(VERSION_FLAG) -extldflags "$(LDFLAGS)"
 override GO_FLAGS += --ldflags '$(GO_LINK_FLAGS)'
-# Always use Go modules
-export GO111MODULE = on
 # Use -trimpath if available
 ifneq "" "$(shell go help build | grep trimpath)"
 override GO_FLAGS += -trimpath

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ information about each of the commands.
 ## Building and installing
 
 `fscrypt` has a minimal set of build dependencies:
-*   [Go](https://golang.org/doc/install) 1.11 or higher. Older versions may work
+*   [Go](https://golang.org/doc/install) 1.16 or higher. Older versions may work
     but they are not tested or supported.
 *   A C compiler (`gcc` or `clang`)
 *   `make`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/fscrypt
 
-go 1.11
+go 1.16
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
Bump up the required Go version to 1.16 so that we can assume that Go
modules are enabled by default.  Go 1.16 is the latest end-of-life
release, so this makes it so that we support the latest end-of-life
release (1.16), the current maintainance release (1.17), the current
release (1.18), and future releases.  This the same approach we took
when we last bumped up the required Go version.

Also update the ci.yml file to test with these versions.