### PR TITLE
fsync set policy ioctls

### DIFF
--- a/metadata/policy_test.go
+++ b/metadata/policy_test.go
@@ -186,7 +186,7 @@ func requireV2PolicySupport(t *testing.T, directory string) {
 	}
 	defer file.Close()
 
-	err = policyIoctl(file, unix.FS_IOC_GET_ENCRYPTION_POLICY_EX, nil)
+	err = getPolicyIoctl(file, unix.FS_IOC_GET_ENCRYPTION_POLICY_EX, nil)
 	if err == ErrEncryptionNotSupported {
 		t.Skip("No support for v2 encryption policies, skipping test")
 	}


### PR DESCRIPTION
Split policyIoctl into setPolicyIoctl and getPolicyIoctl. Add a
os.Sync() call to setPolicyIoctl.

Policy ioctls are not necessary durable on return. For example, on
ext4 (ref: fs/ext4/crypto.c: ext4_set_context) they are not. This may
lead to a filesystem containing fscrypt metadata (in .fscrypt), but
without the policy applied on an encrypted directory.

Example:
Snapshotting a mounted ext4 filesystem on Ceph RBD right after
setting the policy. While subject to timing, with high probability the
snapshot will not have the policy set. Calling fsync fixes this.

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>