### PR TITLE
cli-tests: account for protojson whitespace randomization

### DIFF
--- a/cli-tests/run.sh
+++ b/cli-tests/run.sh
@@ -112,6 +112,10 @@ filter_test_output()
 	# "bash: line 1: " instead of just "bash: ".  Filter out the "line 1: ".
 	sedscript+="s@^bash: line 1: @bash: @;"
 
+	# Work around protojson whitespace randomization.
+	sedscript+="/^Options:  /s@  @ @g;"
+	sedscript+="s@^Options: @Options:  @;"
+
 	sed -e "$sedscript" "$raw_output"
 }
 
@@ -162,7 +166,7 @@ setup_for_test()
 	fscrypt setup --time=1ms --quiet --all-users > /dev/null
 
 	# The tests assume kernel support for v2 policies.
-	if ! grep -q '"policy_version": "2"' "$FSCRYPT_CONF"; then
+	if ! grep -E -q '"policy_version": +"2"' "$FSCRYPT_CONF"; then
 		cat 1>&2 << EOF
 ERROR: Can't run these tests because your kernel doesn't support v2 policies.
 You need kernel v5.4 or later.

--- a/cli-tests/t_v1_policy.sh
+++ b/cli-tests/t_v1_policy.sh
@@ -13,7 +13,7 @@ mkdir "$dir"
 chown "$TEST_USER" "$dir"
 
 _print_header "Set policy_version 1"
-sed -i 's/"policy_version": "2"/"policy_version": "1"/' "$FSCRYPT_CONF"
+sed -E -i 's/"policy_version": +"2"/"policy_version": "1"/' "$FSCRYPT_CONF"
 
 _print_header "Try to encrypt as root"
 _expect_failure "echo hunter2 | fscrypt encrypt --quiet --name=prot '$dir'"

--- a/cli-tests/t_v1_policy_fs_keyring.sh
+++ b/cli-tests/t_v1_policy_fs_keyring.sh
@@ -10,8 +10,8 @@ cd "$(dirname "$0")"
 . common.sh
 
 _print_header "Enable v1 policies with fs keyring"
-sed -e 's/"use_fs_keyring_for_v1_policies": false/"use_fs_keyring_for_v1_policies": true/' \
-    -e 's/"policy_version": "2"/"policy_version": "1"/' \
+sed -E -e 's/"use_fs_keyring_for_v1_policies": +false/"use_fs_keyring_for_v1_policies": true/' \
+    -e 's/"policy_version": +"2"/"policy_version": "1"/' \
     -i "$FSCRYPT_CONF"
 
 dir="$MNT/dir"


### PR DESCRIPTION
Annoyingly, for JSON formatting protojson randomly selects a spacing method (one space or two spaces) depending on a hash of some sections of the Go binary, to discourage depending on its output being stable.  This breaks some checks in the CLI tests of the contents of fscrypt.conf and the output of 'fscrypt status'.  As there doesn't appear to be a straightforward alternative currently, for now just update the tests to take into consideration the possible extra space.