### PR TITLE
Stop using deprecated package io/ioutil

### DIFF
--- a/actions/config_test.go
+++ b/actions/config_test.go
@@ -19,7 +19,6 @@
 package actions
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +36,7 @@ func TestConfigFileIsCreatedWithCorrectMode(t *testing.T) {
 	defer unix.Umask(oldMask)
 	unix.Umask(0077)
 
-	tempDir, err := ioutil.TempDir("", "fscrypt")
+	tempDir, err := os.MkdirTemp("", "fscrypt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +56,7 @@ func TestConfigFileIsCreatedWithCorrectMode(t *testing.T) {
 }
 
 func TestCreateConfigFileV2Policy(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "fscrypt")
+	tempDir, err := os.MkdirTemp("", "fscrypt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/actions/hashing_test.go
+++ b/actions/hashing_test.go
@@ -20,7 +20,7 @@
 package actions
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"testing"
 	"time"
@@ -54,7 +54,7 @@ func TestCostsSearch(t *testing.T) {
 
 func benchmarkCostsSearch(b *testing.B, target time.Duration) {
 	// Disable logging for benchmarks
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	for i := 0; i < b.N; i++ {
 		_, err := getHashingCosts(target)
 		if err != nil {

--- a/actions/recovery_test.go
+++ b/actions/recovery_test.go
@@ -19,7 +19,6 @@
 package actions
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestRecoveryPassphrase(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "fscrypt")
+	tempDir, err := os.MkdirTemp("", "fscrypt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +70,7 @@ func TestRecoveryPassphrase(t *testing.T) {
 		recoveryFile); err != nil {
 		t.Fatal(err)
 	}
-	contentsBytes, err := ioutil.ReadFile(recoveryFile)
+	contentsBytes, err := os.ReadFile(recoveryFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/fscrypt/fscrypt.go
+++ b/cmd/fscrypt/fscrypt.go
@@ -26,7 +26,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -110,8 +110,8 @@ func setupCommand(command *cli.Command) {
 // io.Writers and that we haven't over-specified our flags. We only print the
 // logs when using verbose, and only print normal stuff when not using quiet.
 func setupBefore(c *cli.Context) error {
-	log.SetOutput(ioutil.Discard)
-	c.App.Writer = ioutil.Discard
+	log.SetOutput(io.Discard)
+	c.App.Writer = io.Discard
 
 	if verboseFlag.Value {
 		log.SetOutput(os.Stdout)

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -35,7 +35,6 @@ package filesystem
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/user"
@@ -335,7 +334,7 @@ func (m *Mount) PolicyPath(descriptor string) string {
 // directory and returns a temporary Mount which represents this temporary
 // directory. The caller is responsible for removing this temporary directory.
 func (m *Mount) tempMount() (*Mount, error) {
-	tempDir, err := ioutil.TempDir(filepath.Dir(m.BaseDir()), tempPrefix)
+	tempDir, err := os.MkdirTemp(filepath.Dir(m.BaseDir()), tempPrefix)
 	return &Mount{Path: tempDir}, err
 }
 
@@ -635,7 +634,7 @@ func (m *Mount) writeData(path string, data []byte, owner *user.User, mode os.Fi
 	// Write the data to a temporary file, sync it, then rename into place
 	// so that the operation will be atomic.
 	dirPath := filepath.Dir(path)
-	tempFile, err := ioutil.TempFile(dirPath, tempPrefix)
+	tempFile, err := os.CreateTemp(dirPath, tempPrefix)
 	if err != nil {
 		log.Print(err)
 		if os.IsPermission(err) {
@@ -767,7 +766,7 @@ func readMetadataFileSafe(path string, trustedUser *user.User) ([]byte, int64, e
 	}
 	// Read the file contents, allowing at most maxMetadataFileSize bytes.
 	reader := &io.LimitedReader{R: file, N: maxMetadataFileSize + 1}
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -20,7 +20,6 @@
 package filesystem
 
 import (
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -172,7 +171,7 @@ func TestSetupWithAbsoluteSymlink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tempDir, err := ioutil.TempDir("", "fscrypt")
+	tempDir, err := os.MkdirTemp("", "fscrypt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -519,7 +518,7 @@ func TestLinkedProtector(t *testing.T) {
 }
 
 func createFile(path string, size int64) error {
-	if err := ioutil.WriteFile(path, []byte{}, 0600); err != nil {
+	if err := os.WriteFile(path, []byte{}, 0600); err != nil {
 		return err
 	}
 	return os.Truncate(path, size)
@@ -532,7 +531,7 @@ func TestReadMetadataFileSafe(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tempDir, err := ioutil.TempDir("", "fscrypt")
+	tempDir, err := os.MkdirTemp("", "fscrypt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/filesystem/mountpoint.go
+++ b/filesystem/mountpoint.go
@@ -25,7 +25,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -537,11 +536,15 @@ func getMountFromLink(link string) (*Mount, error) {
 }
 
 func (mnt *Mount) getFilesystemUUID() (string, error) {
-	dirContents, err := ioutil.ReadDir(uuidDirectory)
+	dirEntries, err := os.ReadDir(uuidDirectory)
 	if err != nil {
 		return "", err
 	}
-	for _, fileInfo := range dirContents {
+	for _, dirEntry := range dirEntries {
+		fileInfo, err := dirEntry.Info()
+		if err != nil {
+			continue
+		}
 		if fileInfo.Mode()&os.ModeSymlink == 0 {
 			continue // Only interested in UUID symlinks
 		}

--- a/filesystem/mountpoint_test.go
+++ b/filesystem/mountpoint_test.go
@@ -26,7 +26,6 @@ package filesystem
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -122,7 +121,7 @@ func TestLoadSourceDevice(t *testing.T) {
 func TestNondirectoryMountsIgnored(t *testing.T) {
 	beginLoadMountInfoTest()
 	defer endLoadMountInfoTest()
-	file, err := ioutil.TempFile("", "fscrypt_regfile")
+	file, err := os.CreateTemp("", "fscrypt_regfile")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +154,7 @@ func TestNonLatestMountsIgnored(t *testing.T) {
 
 // Test that escape sequences in the mountinfo file are unescaped correctly.
 func TestLoadMountWithSpecialCharacters(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "fscrypt")
+	tempDir, err := os.MkdirTemp("", "fscrypt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,7 +295,7 @@ func TestRootMountpointIsPreferred(t *testing.T) {
 // Test that a mountpoint that is not "/" but still contains all other
 // mountpoints is preferred, given independent subtrees.
 func TestHighestMountpointIsPreferred(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "fscrypt")
+	tempDir, err := os.MkdirTemp("", "fscrypt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +330,7 @@ func TestHighestMountpointIsPreferred(t *testing.T) {
 // mountpoints are contained in other mountpoints, the chosen Mount is the root
 // of a tree of mountpoints whose mounted subtrees contain all mounted subtrees.
 func TestLoadContainedSubtreesAndMountpoints(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "fscrypt")
+	tempDir, err := os.MkdirTemp("", "fscrypt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/filesystem/path_test.go
+++ b/filesystem/path_test.go
@@ -20,7 +20,6 @@ package filesystem
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -61,7 +60,7 @@ func TestHaveReadAccessTo(t *testing.T) {
 	if util.IsUserRoot() {
 		t.Skip("This test cannot be run as root")
 	}
-	file, err := ioutil.TempFile("", "fscrypt_test")
+	file, err := os.CreateTemp("", "fscrypt_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metadata/config.go
+++ b/metadata/config.go
@@ -28,7 +28,6 @@ package metadata
 
 import (
 	"io"
-	"io/ioutil"
 
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -55,7 +54,7 @@ func WriteConfig(config *Config, out io.Writer) error {
 
 // ReadConfig writes the JSON data into the config structure
 func ReadConfig(in io.Reader) (*Config, error) {
-	bytes, err := ioutil.ReadAll(in)
+	bytes, err := io.ReadAll(in)
 	if err != nil {
 		return nil, err
 	}

--- a/pam_fscrypt/run_fscrypt.go
+++ b/pam_fscrypt/run_fscrypt.go
@@ -31,7 +31,6 @@ import "C"
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"log/syslog"
 	"os"
@@ -132,7 +131,7 @@ func parseArgs(argc C.int, argv **C.char) map[string]bool {
 // syslog.
 func setupLogging(args map[string]bool) io.Writer {
 	log.SetFlags(0) // Syslog already includes time data itself
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	if args[debugFlag] {
 		debugWriter, err := syslog.New(syslog.LOG_DEBUG, moduleName)
 		if err == nil {
@@ -142,7 +141,7 @@ func setupLogging(args map[string]bool) io.Writer {
 
 	errorWriter, err := syslog.New(syslog.LOG_ERR, moduleName)
 	if err != nil {
-		return ioutil.Discard
+		return io.Discard
 	}
 	return errorWriter
 }


### PR DESCRIPTION
Since Go 1.16 (which recently became the minimum supported Go version for this project), the package io/ioutil is deprecated in favor of equivalent functionality in the io and os packages.  staticcheck warns about this.  Address all the warnings by switching to the non-deprecated replacement functions.