### PR TITLE
Stop using golang.org/x/lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ C_FILES := $(filter %.c %.h,$(FILES))
 PROTO_FILES := $(filter %.proto,$(FILES))
 
 ###### Build, Formatting, and Linting Commands ######
-.PHONY: default all gen format clean
+.PHONY: default all gen format lint clean
 default: $(BIN)/$(NAME) $(PAM_MODULE)
 all: tools gen default format lint test
 


### PR DESCRIPTION
golint is not supported anymore.  See
https://github.com/golang/go/issues/38968.

We already use both 'go vet' and 'staticheck' which are maintained.