### PR TITLE
Provide better error message when given a locked regular file

### DIFF
--- a/cli-tests/t_lock.out
+++ b/cli-tests/t_lock.out
@@ -85,3 +85,18 @@ If you want to force the directory to be locked, use:
 contents
 "MNT/dir" is now locked.
 cat: MNT/dir/file: No such file or directory
+
+# Try to operate on locked regular file
+"MNT/dir" is now locked.
+[ERROR] fscrypt status: cannot operate on locked regular file
+                        "MNT/file"
+
+It is not possible to operate directly on a locked regular file, since the
+kernel does not support this. Specify the parent directory instead. (For loose
+files, any directory with the file's policy works.)
+[ERROR] fscrypt unlock: cannot operate on locked regular file
+                        "MNT/file"
+
+It is not possible to operate directly on a locked regular file, since the
+kernel does not support this. Specify the parent directory instead. (For loose
+files, any directory with the file's policy works.)

--- a/cli-tests/t_lock.sh
+++ b/cli-tests/t_lock.sh
@@ -52,3 +52,14 @@ _expect_failure "fscrypt lock '$dir'"
 cat "$dir/file"
 fscrypt lock --all-users "$dir"
 _expect_failure "cat '$dir/file'"
+
+_print_header "Try to operate on locked regular file"
+_reset_filesystems
+rm -rf "$dir"
+mkdir "$dir"
+echo hunter2 | fscrypt encrypt --quiet --name=prot "$dir"
+echo contents > "$dir/file"
+mv "$dir/file" "$MNT/file"  # Make it a loose encrypted file.
+fscrypt lock "$dir"
+_expect_failure "fscrypt status '$MNT/file'"
+_expect_failure "fscrypt unlock '$MNT/file'"

--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -251,6 +251,11 @@ func getErrorSuggestions(err error) string {
 		return `This is usually the result of a bad PAM configuration.
 			Either correct the problem in your PAM stack, enable
 			pam_keyinit.so, or run "keyctl link @u @s".`
+	case *metadata.ErrLockedRegularFile:
+		return `It is not possible to operate directly on a locked
+			regular file, since the kernel does not support this.
+			Specify the parent directory instead. (For loose files,
+			any directory with the file's policy works.)`
 	}
 	switch errors.Cause(err) {
 	case crypto.ErrMlockUlimit:


### PR DESCRIPTION
Since opening an encrypted regular file that is locked fails with ENOKEY, getting the encryption policy of such a file is not possible. As a result, 'fscrypt status' and 'fscrypt lock' fail on such files. Provide a better error message that tries to explain what is going on.

Resolves https://github.com/google/fscrypt/issues/393