### PR TITLE
Fix non-constant format string passed to errors.Wrapf()

### DIFF
--- a/cmd/fscrypt/commands.go
+++ b/cmd/fscrypt/commands.go
@@ -414,7 +414,7 @@ func unlockAction(c *cli.Context) error {
 	if policy.IsProvisionedByTargetUser() {
 		log.Printf("policy %s is already provisioned by %v",
 			policy.Descriptor(), ctx.TargetUser.Username)
-		return newExitError(c, errors.Wrapf(ErrDirAlreadyUnlocked, path))
+		return newExitError(c, errors.Wrap(ErrDirAlreadyUnlocked, path))
 	}
 
 	if err := policy.Unlock(optionFn, existingKeyFn); err != nil {
@@ -521,7 +521,7 @@ func lockAction(c *cli.Context) error {
 		// locking the directory by dropping caches again.
 		if !policy.NeedsUserKeyring() || !isDirUnlockedHeuristic(path) {
 			log.Printf("policy %s is already fully deprovisioned", policy.Descriptor())
-			return newExitError(c, errors.Wrapf(ErrDirAlreadyLocked, path))
+			return newExitError(c, errors.Wrap(ErrDirAlreadyLocked, path))
 		}
 	}
 


### PR DESCRIPTION
Do not pass a path as the format string argument to errors.Wrapf(), as this causes it to be misinterpreted as a format string, causing an unexpected message if the path contains something like '%s'.  Instead use errors.Wrap().  This was diagnosed by Go 1.24.

Fixes https://github.com/google/fscrypt/issues/422