### PR TITLE
recovery: add O_NOFOLLOW|O_EXCL to prevent symlink-following in recovery file creation

### DIFF
--- a/actions/recovery.go
+++ b/actions/recovery.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strconv"
 
+	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/google/fscrypt/crypto"
@@ -91,7 +92,7 @@ func AddRecoveryPassphrase(policy *Policy, dirname string) (*crypto.Key, *Protec
 // passphrase in a different location if they actually need it.
 func WriteRecoveryInstructions(recoveryPassphrase *crypto.Key, recoveryProtector *Protector,
 	policy *Policy, path string) error {
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0600)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL|unix.O_NOFOLLOW, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
WriteRecoveryInstructions() at recovery.go:94 opens the recovery README
with os.O_WRONLY|os.O_CREATE without O_NOFOLLOW. When fscrypt encrypt
runs as root via sudo, a local attacker who controls the parent directory
can place a symlink at the recovery file path, causing root to write
through the symlink and fchown the target to the attacker.

The rest of the codebase uses O_NOFOLLOW consistently:
- filesystem.go:608: os.O_WRONLY|os.O_TRUNC|unix.O_NOFOLLOW
- filesystem.go:747: os.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK

This change adds os.O_EXCL|unix.O_NOFOLLOW to align with the existing
security pattern.