### PR TITLE
cmd/fscrypt: mention --unlock-with in protector error hint

### DIFF
--- a/cmd/fscrypt/errors.go
+++ b/cmd/fscrypt/errors.go
@@ -272,7 +272,8 @@ func getErrorSuggestions(err error) string {
 		return fmt.Sprintf("If desired, use %s to automatically run destructive operations.",
 			shortDisplay(forceFlag))
 	case ErrSpecifyProtector:
-		return fmt.Sprintf("Use %s to specify a protector.", shortDisplay(protectorFlag))
+		return fmt.Sprintf("Use %s or %s to specify a protector.",
+			shortDisplay(protectorFlag), shortDisplay(unlockWithFlag))
 	case ErrSpecifyKeyFile:
 		return fmt.Sprintf("Use %s to specify a key file.", shortDisplay(keyFileFlag))
 	case ErrDropCachesPerm:


### PR DESCRIPTION
Fixes #439. The error hint for multiple protectors only mentioned `--protector`, but for the `unlock` command the correct flag is `--unlock-with`. Now both flags are shown.