### PR TITLE
Don't retry passwords if `fscrypt unlock` doesn't have a tty

### DIFF
--- a/cli-tests/t_unlock.out
+++ b/cli-tests/t_unlock.out
@@ -62,6 +62,30 @@ Protected with 1 protector:
 PROTECTOR         LINKED  DESCRIPTION
 desc2  No      custom protector "prot"
 
+# Try to unlock with no stdin
+[ERROR] fscrypt unlock: incorrect key provided
+"MNT/dir" is encrypted with fscrypt.
+
+Policy:   desc1
+Options:  padding:32 contents:AES_256_XTS filenames:AES_256_CTS policy_version:2
+Unlocked: No
+
+Protected with 1 protector:
+PROTECTOR         LINKED  DESCRIPTION
+desc2  No      custom protector "prot"
+
+# Try to unlock with only a newline
+[ERROR] fscrypt unlock: incorrect key provided
+"MNT/dir" is encrypted with fscrypt.
+
+Policy:   desc1
+Options:  padding:32 contents:AES_256_XTS filenames:AES_256_CTS policy_version:2
+Unlocked: No
+
+Protected with 1 protector:
+PROTECTOR         LINKED  DESCRIPTION
+desc2  No      custom protector "prot"
+
 # Unlock directory
 Enter custom passphrase for protector "prot": "MNT/dir" is now unlocked and ready for use.
 
@@ -90,7 +114,7 @@ desc1  Yes       desc2
                         the policy metadata for "MNT/dir".
                         This directory has either been encrypted with another
                         tool (such as e4crypt), or the file
-                        "MNT/.fscrypt/policies/desc20"
+                        "MNT/.fscrypt/policies/desc24"
                         has been deleted.
 
 # Try to unlock with missing protector metadata
@@ -103,14 +127,14 @@ information.
 [ERROR] fscrypt unlock: inconsistent metadata between encrypted directory
                         "MNT/dir1" and its corresponding
                         metadata file
-                        "MNT/.fscrypt/policies/desc21".
+                        "MNT/.fscrypt/policies/desc25".
 
                         Directory has
-                        descriptor:desc21 padding:32
+                        descriptor:desc25 padding:32
                         contents:AES_256_XTS filenames:AES_256_CTS
                         policy_version:2
 
                         Metadata file has
-                        descriptor:desc23 padding:32
+                        descriptor:desc27 padding:32
                         contents:AES_256_XTS filenames:AES_256_CTS
                         policy_version:2

--- a/cli-tests/t_unlock.sh
+++ b/cli-tests/t_unlock.sh
@@ -38,6 +38,14 @@ _print_header "Try to unlock with wrong passphrase"
 _expect_failure "echo bad | fscrypt unlock --quiet '$dir'"
 fscrypt status "$dir"
 
+_print_header "Try to unlock with no stdin"
+_expect_failure "fscrypt unlock --quiet '$dir' </dev/null"
+fscrypt status "$dir"
+
+_print_header "Try to unlock with only a newline"
+_expect_failure "echo | fscrypt unlock --quiet '$dir'"
+fscrypt status "$dir"
+
 _print_header "Unlock directory"
 echo hunter2 | fscrypt unlock "$dir"
 _print_header "=> Check dir status"

--- a/cmd/fscrypt/keys.go
+++ b/cmd/fscrypt/keys.go
@@ -145,7 +145,7 @@ func makeKeyFunc(supportRetry, shouldConfirm bool, prefix string) actions.KeyFun
 				panic("this KeyFunc does not support retrying")
 			}
 			// Don't retry for non-interactive sessions
-			if quietFlag.Value {
+			if quietFlag.Value || !term.IsTerminal(stdinFd) {
 				return nil, ErrWrongKey
 			}
 			fmt.Println("Incorrect Passphrase")


### PR DESCRIPTION
Fixes https://github.com/google/fscrypt/issues/429