### PR TITLE
Don't retry key files specified with --key=FILE

### DIFF
--- a/cli-tests/t_encrypt_raw_key.out
+++ b/cli-tests/t_encrypt_raw_key.out
@@ -72,3 +72,25 @@ Unlocked: Yes
 Protected with 1 protector:
 PROTECTOR         LINKED  DESCRIPTION
 desc11  No      raw key protector "prot"
+
+# Try to unlock with wrong key, both with and without --quiet
+"MNT/dir" is now locked.
+[ERROR] fscrypt unlock: incorrect key provided
+[ERROR] fscrypt unlock: incorrect key provided
+ext4 filesystem "MNT" has 1 protector and 1 policy.
+All users can create fscrypt metadata on this filesystem.
+
+PROTECTOR         LINKED  DESCRIPTION
+desc16  No      raw key protector "prot"
+
+POLICY                            UNLOCKED  PROTECTORS
+desc17  No        desc16
+"MNT/dir" is encrypted with fscrypt.
+
+Policy:   desc17
+Options:  padding:32 contents:AES_256_XTS filenames:AES_256_CTS policy_version:2
+Unlocked: No
+
+Protected with 1 protector:
+PROTECTOR         LINKED  DESCRIPTION
+desc16  No      raw key protector "prot"

--- a/cli-tests/t_encrypt_raw_key.sh
+++ b/cli-tests/t_encrypt_raw_key.sh
@@ -51,3 +51,12 @@ fscrypt encrypt --quiet --name=prot --source=raw_key --key="$raw_key_file" "$dir
 fscrypt lock "$dir"
 fscrypt unlock --quiet "$dir" < "$raw_key_file"
 show_status true
+
+begin "Try to unlock with wrong key, both with and without --quiet"
+head -c 32 /dev/urandom > "$raw_key_file"
+fscrypt encrypt --quiet --name=prot --source=raw_key --key="$raw_key_file" "$dir"
+fscrypt lock "$dir"
+head -c 32 /dev/urandom > "$raw_key_file"
+_expect_failure "fscrypt unlock --quiet --key='$raw_key_file' '$dir'"
+_expect_failure "fscrypt unlock --key='$raw_key_file' '$dir'"
+show_status true

--- a/cmd/fscrypt/keys.go
+++ b/cmd/fscrypt/keys.go
@@ -144,11 +144,17 @@ func makeKeyFunc(supportRetry, shouldConfirm bool, prefix string) actions.KeyFun
 			if !supportRetry {
 				panic("this KeyFunc does not support retrying")
 			}
-			// Don't retry for non-interactive sessions
-			if quietFlag.Value || !term.IsTerminal(stdinFd) {
+			// Don't retry in --quiet mode, for non-interactive
+			// sessions, or when a key file was specified.
+			if quietFlag.Value || !term.IsTerminal(stdinFd) ||
+				(info.Source() == metadata.SourceType_raw_key && keyFileFlag.Value != "") {
 				return nil, ErrWrongKey
 			}
-			fmt.Println("Incorrect Passphrase")
+			if info.Source() == metadata.SourceType_raw_key {
+				fmt.Println("Incorrect Key")
+			} else {
+				fmt.Println("Incorrect Passphrase")
+			}
 		}
 
 		switch info.Source() {


### PR DESCRIPTION
Also print "Incorrect Key" instead of "Incorrect Passphrase" when an incorrect key file is specified interactively.

Fixes https://github.com/google/fscrypt/issues/457